### PR TITLE
Update ExtrinsicStatus Enum

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -447,8 +447,8 @@ func Example_transactionWithEvents() {
 		status := <-sub.Chan()
 		fmt.Printf("Transaction status: %#v\n", status)
 
-		if status.IsFinalized {
-			fmt.Printf("Completed at block hash: %#x\n", status.AsFinalized)
+		if status.IsInBlock {
+			fmt.Printf("Completed at block hash: %#x\n", status.AsInBlock)
 			return
 		}
 	}

--- a/teste2e/author_submit_and_watch_extrinsic_test.go
+++ b/teste2e/author_submit_and_watch_extrinsic_test.go
@@ -114,8 +114,8 @@ func TestAuthor_SubmitAndWatchExtrinsic(t *testing.T) {
 		case status := <-sub.Chan():
 			fmt.Printf("%#v\n", status)
 
-			if status.IsFinalized {
-				assert.False(t, types.Eq(status.AsFinalized, types.ExtrinsicStatus{}.AsFinalized),
+			if status.IsInBlock {
+				assert.False(t, types.Eq(status.AsInBlock, types.ExtrinsicStatus{}.AsInBlock),
 					"expected AsFinalized not to be empty")
 				return
 			}

--- a/types/extrinsic_status.go
+++ b/types/extrinsic_status.go
@@ -28,12 +28,12 @@ import (
 type ExtrinsicStatus struct {
 	IsFuture    bool // 00:: Future
 	IsReady     bool // 1:: Ready
-	IsFinalized bool // 2:: Finalized(Hash)
-	AsFinalized Hash
+	IsBroadcast bool // 2:: Broadcast(Vec<Text>)
+	AsBroadcast []Text
+	IsInBlock	bool // 3:: InBlock(BlockHash)
+	AsInBlock Hash
 	IsUsurped   bool // 3:: Usurped(Hash)
 	AsUsurped   Hash
-	IsBroadcast bool // 4:: Broadcast(Vec<Text>)
-	AsBroadcast []Text
 	IsDropped   bool // 5:: Dropped
 	IsInvalid   bool // 6:: Invalid
 }
@@ -51,14 +51,14 @@ func (e *ExtrinsicStatus) Decode(decoder scale.Decoder) error {
 	case 1:
 		e.IsReady = true
 	case 2:
-		e.IsFinalized = true
-		err = decoder.Decode(&e.AsFinalized)
-	case 3:
-		e.IsUsurped = true
-		err = decoder.Decode(&e.AsUsurped)
-	case 4:
 		e.IsBroadcast = true
 		err = decoder.Decode(&e.AsBroadcast)
+	case 3:
+		e.IsInBlock = true
+		err = decoder.Decode(&e.AsInBlock)
+	case 4:
+		e.IsUsurped = true
+		err = decoder.Decode(&e.AsUsurped)
 	case 5:
 		e.IsDropped = true
 	case 6:
@@ -79,15 +79,15 @@ func (e ExtrinsicStatus) Encode(encoder scale.Encoder) error {
 		err1 = encoder.PushByte(0)
 	case e.IsReady:
 		err1 = encoder.PushByte(1)
-	case e.IsFinalized:
-		err1 = encoder.PushByte(2)
-		err2 = encoder.Encode(e.AsFinalized)
-	case e.IsUsurped:
-		err1 = encoder.PushByte(3)
-		err2 = encoder.Encode(e.AsUsurped)
 	case e.IsBroadcast:
-		err1 = encoder.PushByte(4)
+		err1 = encoder.PushByte(2)
 		err2 = encoder.Encode(e.AsBroadcast)
+	case e.IsInBlock:
+		err1 = encoder.PushByte(3)
+		err2 = encoder.Encode(e.AsInBlock)
+	case e.IsUsurped:
+		err1 = encoder.PushByte(4)
+		err2 = encoder.Encode(e.AsUsurped)
 	case e.IsDropped:
 		err1 = encoder.PushByte(5)
 	case e.IsInvalid:
@@ -136,9 +136,9 @@ func (e *ExtrinsicStatus) UnmarshalJSON(b []byte) error {
 	}
 
 	switch {
-	case strings.HasPrefix(input, "{\"finalized\""):
-		e.IsFinalized = true
-		e.AsFinalized = tmp.AsFinalized
+	case strings.HasPrefix(input, "{\"inBlock\""):
+		e.IsInBlock = true
+		e.AsInBlock = tmp.AsFinalized
 		return nil
 	case strings.HasPrefix(input, "{\"usurped\""):
 		e.IsUsurped = true
@@ -163,11 +163,11 @@ func (e ExtrinsicStatus) MarshalJSON() ([]byte, error) {
 		return []byte("\"dropped\""), nil
 	case e.IsInvalid:
 		return []byte("\"invalid\""), nil
-	case e.IsFinalized:
+	case e.IsInBlock:
 		var tmp struct {
 			AsFinalized Hash `json:"finalized"`
 		}
-		tmp.AsFinalized = e.AsFinalized
+		tmp.AsFinalized = e.AsInBlock
 		return json.Marshal(tmp)
 	case e.IsUsurped:
 		var tmp struct {

--- a/types/extrinsic_status.go
+++ b/types/extrinsic_status.go
@@ -30,8 +30,8 @@ type ExtrinsicStatus struct {
 	IsReady     bool // 1:: Ready
 	IsBroadcast bool // 2:: Broadcast(Vec<Text>)
 	AsBroadcast []Text
-	IsInBlock	bool // 3:: InBlock(BlockHash)
-	AsInBlock Hash
+	IsInBlock   bool // 3:: InBlock(BlockHash)
+	AsInBlock   Hash
 	IsUsurped   bool // 3:: Usurped(Hash)
 	AsUsurped   Hash
 	IsDropped   bool // 5:: Dropped

--- a/types/extrinsic_status.go
+++ b/types/extrinsic_status.go
@@ -32,7 +32,7 @@ type ExtrinsicStatus struct {
 	AsBroadcast []Text
 	IsInBlock   bool // 3:: InBlock(BlockHash)
 	AsInBlock   Hash
-	IsUsurped   bool // 3:: Usurped(Hash)
+	IsUsurped   bool // 4:: Usurped(Hash)
 	AsUsurped   Hash
 	IsDropped   bool // 5:: Dropped
 	IsInvalid   bool // 6:: Invalid
@@ -127,7 +127,7 @@ func (e *ExtrinsicStatus) UnmarshalJSON(b []byte) error {
 
 	// no simple case, decode into helper
 	var tmp struct {
-		AsFinalized Hash   `json:"finalized"`
+		AsInBlock   Hash   `json:"inBlock"`
 		AsUsurped   Hash   `json:"usurped"`
 		AsBroadcast []Text `json:"broadcast"`
 	}
@@ -138,7 +138,7 @@ func (e *ExtrinsicStatus) UnmarshalJSON(b []byte) error {
 	switch {
 	case strings.HasPrefix(input, "{\"inBlock\""):
 		e.IsInBlock = true
-		e.AsInBlock = tmp.AsFinalized
+		e.AsInBlock = tmp.AsInBlock
 		return nil
 	case strings.HasPrefix(input, "{\"usurped\""):
 		e.IsUsurped = true
@@ -165,9 +165,9 @@ func (e ExtrinsicStatus) MarshalJSON() ([]byte, error) {
 		return []byte("\"invalid\""), nil
 	case e.IsInBlock:
 		var tmp struct {
-			AsFinalized Hash `json:"finalized"`
+			AsInBlock Hash `json:"inBlock"`
 		}
-		tmp.AsFinalized = e.AsInBlock
+		tmp.AsInBlock = e.AsInBlock
 		return json.Marshal(tmp)
 	case e.IsUsurped:
 		var tmp struct {

--- a/types/extrinsic_status_test.go
+++ b/types/extrinsic_status_test.go
@@ -24,15 +24,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testExtrinsicStatus1 = ExtrinsicStatus{IsFuture: true}
-var testExtrinsicStatus2 = ExtrinsicStatus{IsReady: true}
-var testExtrinsicStatus3 = ExtrinsicStatus{IsInBlock: true, AsInBlock: NewHash([]byte{0xab})}
-var testExtrinsicStatus4 = ExtrinsicStatus{IsUsurped: true, AsUsurped: NewHash([]byte{0xcd})}
-var testExtrinsicStatus5 = ExtrinsicStatus{IsBroadcast: true, AsBroadcast: []Text{"This", "is", "broadcast"}}
-var testExtrinsicStatus6 = ExtrinsicStatus{IsDropped: true}
-var testExtrinsicStatus7 = ExtrinsicStatus{IsInvalid: true}
+var testExtrinsicStatus0 = ExtrinsicStatus{IsFuture: true}
+var testExtrinsicStatus1 = ExtrinsicStatus{IsReady: true}
+var testExtrinsicStatus2 = ExtrinsicStatus{IsBroadcast: true, AsBroadcast: []Text{"This", "is", "broadcast"}}
+var testExtrinsicStatus3 = ExtrinsicStatus{IsInBlock: true, AsInBlock: NewHash([]byte{0xaa})}
+var testExtrinsicStatus4 = ExtrinsicStatus{IsRetracted: true, AsRetracted: NewHash([]byte{0xbb})}
+var testExtrinsicStatus5 = ExtrinsicStatus{IsFinalityTimeout: true, AsFinalityTimeout: NewHash([]byte{0xcc})}
+var testExtrinsicStatus6 = ExtrinsicStatus{IsFinalized: true, AsFinalized: NewHash([]byte{0xdd})}
+var testExtrinsicStatus7 = ExtrinsicStatus{IsUsurped: true, AsUsurped: NewHash([]byte{0xee})}
+var testExtrinsicStatus8 = ExtrinsicStatus{IsDropped: true}
+var testExtrinsicStatus9 = ExtrinsicStatus{IsInvalid: true}
 
 func TestExtrinsicStatus_EncodeDecode(t *testing.T) {
+	assertRoundtrip(t, testExtrinsicStatus0)
 	assertRoundtrip(t, testExtrinsicStatus1)
 	assertRoundtrip(t, testExtrinsicStatus2)
 	assertRoundtrip(t, testExtrinsicStatus3)
@@ -40,29 +44,37 @@ func TestExtrinsicStatus_EncodeDecode(t *testing.T) {
 	assertRoundtrip(t, testExtrinsicStatus5)
 	assertRoundtrip(t, testExtrinsicStatus6)
 	assertRoundtrip(t, testExtrinsicStatus7)
+	assertRoundtrip(t, testExtrinsicStatus8)
+	assertRoundtrip(t, testExtrinsicStatus9)
 }
 
 func TestExtrinsicStatus_Encode(t *testing.T) {
 	assertEncode(t, []encodingAssert{
-		{testExtrinsicStatus1, []byte{0x00}},
-		{testExtrinsicStatus2, []byte{0x01}},
-		{testExtrinsicStatus3, MustHexDecodeString("0x03ab00000000000000000000000000000000000000000000000000000000000000")}, //nolint:lll
-		{testExtrinsicStatus4, MustHexDecodeString("0x04cd00000000000000000000000000000000000000000000000000000000000000")}, //nolint:lll
-		{testExtrinsicStatus5, MustHexDecodeString("0x020c10546869730869732462726f616463617374")},
-		{testExtrinsicStatus6, []byte{0x05}},
-		{testExtrinsicStatus7, []byte{0x06}},
+		{testExtrinsicStatus0, []byte{0x00}},
+		{testExtrinsicStatus1, []byte{0x01}},
+		{testExtrinsicStatus2, MustHexDecodeString("0x020c10546869730869732462726f616463617374")},
+		{testExtrinsicStatus3, MustHexDecodeString("0x03aa00000000000000000000000000000000000000000000000000000000000000")}, //nolint:lll
+		{testExtrinsicStatus4, MustHexDecodeString("0x04bb00000000000000000000000000000000000000000000000000000000000000")}, //nolint:lll
+		{testExtrinsicStatus5, MustHexDecodeString("0x05cc00000000000000000000000000000000000000000000000000000000000000")}, //nolint:lll
+		{testExtrinsicStatus6, MustHexDecodeString("0x06dd00000000000000000000000000000000000000000000000000000000000000")}, //nolint:lll
+		{testExtrinsicStatus7, MustHexDecodeString("0x07ee00000000000000000000000000000000000000000000000000000000000000")}, //nolint:lll
+		{testExtrinsicStatus8, []byte{0x08}},
+		{testExtrinsicStatus9, []byte{0x09}},
 	})
 }
 
 func TestExtrinsicStatus_Decode(t *testing.T) {
 	assertDecode(t, []decodingAssert{
-		{[]byte{0x00}, testExtrinsicStatus1},
-		{[]byte{0x01}, testExtrinsicStatus2},
-		{MustHexDecodeString("0x03ab00000000000000000000000000000000000000000000000000000000000000"), testExtrinsicStatus3}, //nolint:lll
-		{MustHexDecodeString("0x04cd00000000000000000000000000000000000000000000000000000000000000"), testExtrinsicStatus4}, //nolint:lll
-		{MustHexDecodeString("0x020c10546869730869732462726f616463617374"), testExtrinsicStatus5},
-		{[]byte{0x05}, testExtrinsicStatus6},
-		{[]byte{0x06}, testExtrinsicStatus7},
+		{[]byte{0x00}, testExtrinsicStatus0},
+		{[]byte{0x01}, testExtrinsicStatus1},
+		{MustHexDecodeString("0x020c10546869730869732462726f616463617374"), testExtrinsicStatus2},
+		{MustHexDecodeString("0x03aa00000000000000000000000000000000000000000000000000000000000000"), testExtrinsicStatus3}, //nolint:lll
+		{MustHexDecodeString("0x04bb00000000000000000000000000000000000000000000000000000000000000"), testExtrinsicStatus4}, //nolint:lll
+		{MustHexDecodeString("0x05cc00000000000000000000000000000000000000000000000000000000000000"), testExtrinsicStatus5}, //nolint:lll
+		{MustHexDecodeString("0x06dd00000000000000000000000000000000000000000000000000000000000000"), testExtrinsicStatus6}, //nolint:lll
+		{MustHexDecodeString("0x07ee00000000000000000000000000000000000000000000000000000000000000"), testExtrinsicStatus7}, //nolint:lll
+		{[]byte{0x08}, testExtrinsicStatus8},
+		{[]byte{0x09}, testExtrinsicStatus9},
 	})
 }
 
@@ -70,18 +82,42 @@ var testExtrinsicStatusTestCases = []struct {
 	encoded []byte
 	decoded ExtrinsicStatus
 }{
-	{[]byte("\"future\""), ExtrinsicStatus{IsFuture: true}},
-	{[]byte("\"ready\""), ExtrinsicStatus{IsReady: true}},
-	{[]byte("{\"inBlock\":\"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8f8\"}"),
+	{
+		[]byte("\"future\""),
+		ExtrinsicStatus{IsFuture: true},
+	}, {
+		[]byte("\"ready\""),
+		ExtrinsicStatus{IsReady: true},
+	}, {
+		[]byte("{\"broadcast\":[\"hello\",\"world\"]}"),
+		ExtrinsicStatus{IsBroadcast: true, AsBroadcast: []Text{"hello", "world"}},
+	}, {
+		[]byte("{\"inBlock\":\"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8f8\"}"),
 		ExtrinsicStatus{IsInBlock: true, AsInBlock: NewHash(MustHexDecodeString(
-			"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8f8"))}},
-	{[]byte("{\"usurped\":\"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8ab\"}"),
+			"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8f8"))},
+	}, {
+		[]byte("{\"retracted\":\"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8f8\"}"),
+		ExtrinsicStatus{IsRetracted: true, AsRetracted: NewHash(MustHexDecodeString(
+			"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8f8"))},
+	}, {
+		[]byte("{\"finalityTimeout\":\"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8f8\"}"),
+		ExtrinsicStatus{IsFinalityTimeout: true, AsFinalityTimeout: NewHash(MustHexDecodeString(
+			"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8f8"))},
+	}, {
+		[]byte("{\"finalized\":\"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8f8\"}"),
+		ExtrinsicStatus{IsFinalized: true, AsFinalized: NewHash(MustHexDecodeString(
+			"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8f8"))},
+	}, {
+		[]byte("{\"usurped\":\"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8ab\"}"),
 		ExtrinsicStatus{IsUsurped: true, AsUsurped: NewHash(MustHexDecodeString(
-			"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8ab"))}},
-	{[]byte("{\"broadcast\":[\"hello\",\"world\"]}"),
-		ExtrinsicStatus{IsBroadcast: true, AsBroadcast: []Text{"hello", "world"}}},
-	{[]byte("\"dropped\""), ExtrinsicStatus{IsDropped: true}},
-	{[]byte("\"invalid\""), ExtrinsicStatus{IsInvalid: true}},
+			"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8ab"))},
+	}, {
+		[]byte("\"dropped\""),
+		ExtrinsicStatus{IsDropped: true},
+	}, {
+		[]byte("\"invalid\""),
+		ExtrinsicStatus{IsInvalid: true},
+	},
 }
 
 func TestExtrinsicStatus_UnmarshalJSON(t *testing.T) {

--- a/types/extrinsic_status_test.go
+++ b/types/extrinsic_status_test.go
@@ -26,7 +26,7 @@ import (
 
 var testExtrinsicStatus1 = ExtrinsicStatus{IsFuture: true}
 var testExtrinsicStatus2 = ExtrinsicStatus{IsReady: true}
-var testExtrinsicStatus3 = ExtrinsicStatus{IsFinalized: true, AsFinalized: NewHash([]byte{0xab})}
+var testExtrinsicStatus3 = ExtrinsicStatus{IsInBlock: true, AsInBlock: NewHash([]byte{0xab})}
 var testExtrinsicStatus4 = ExtrinsicStatus{IsUsurped: true, AsUsurped: NewHash([]byte{0xcd})}
 var testExtrinsicStatus5 = ExtrinsicStatus{IsBroadcast: true, AsBroadcast: []Text{"This", "is", "broadcast"}}
 var testExtrinsicStatus6 = ExtrinsicStatus{IsDropped: true}
@@ -72,8 +72,8 @@ var testExtrinsicStatusTestCases = []struct {
 }{
 	{[]byte("\"future\""), ExtrinsicStatus{IsFuture: true}},
 	{[]byte("\"ready\""), ExtrinsicStatus{IsReady: true}},
-	{[]byte("{\"finalized\":\"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8f8\"}"),
-		ExtrinsicStatus{IsFinalized: true, AsFinalized: NewHash(MustHexDecodeString(
+	{[]byte("{\"inBlock\":\"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8f8\"}"),
+		ExtrinsicStatus{IsInBlock: true, AsInBlock: NewHash(MustHexDecodeString(
 			"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8f8"))}},
 	{[]byte("{\"usurped\":\"0x95e3b7f86541d06306691a2fe8cbd935d0bdd28ea14fe515e2db0fa87847f8ab\"}"),
 		ExtrinsicStatus{IsUsurped: true, AsUsurped: NewHash(MustHexDecodeString(

--- a/types/extrinsic_status_test.go
+++ b/types/extrinsic_status_test.go
@@ -46,9 +46,9 @@ func TestExtrinsicStatus_Encode(t *testing.T) {
 	assertEncode(t, []encodingAssert{
 		{testExtrinsicStatus1, []byte{0x00}},
 		{testExtrinsicStatus2, []byte{0x01}},
-		{testExtrinsicStatus3, MustHexDecodeString("0x02ab00000000000000000000000000000000000000000000000000000000000000")}, //nolint:lll
-		{testExtrinsicStatus4, MustHexDecodeString("0x03cd00000000000000000000000000000000000000000000000000000000000000")}, //nolint:lll
-		{testExtrinsicStatus5, MustHexDecodeString("0x040c10546869730869732462726f616463617374")},
+		{testExtrinsicStatus3, MustHexDecodeString("0x03ab00000000000000000000000000000000000000000000000000000000000000")}, //nolint:lll
+		{testExtrinsicStatus4, MustHexDecodeString("0x04cd00000000000000000000000000000000000000000000000000000000000000")}, //nolint:lll
+		{testExtrinsicStatus5, MustHexDecodeString("0x020c10546869730869732462726f616463617374")},
 		{testExtrinsicStatus6, []byte{0x05}},
 		{testExtrinsicStatus7, []byte{0x06}},
 	})
@@ -58,9 +58,9 @@ func TestExtrinsicStatus_Decode(t *testing.T) {
 	assertDecode(t, []decodingAssert{
 		{[]byte{0x00}, testExtrinsicStatus1},
 		{[]byte{0x01}, testExtrinsicStatus2},
-		{MustHexDecodeString("0x02ab00000000000000000000000000000000000000000000000000000000000000"), testExtrinsicStatus3}, //nolint:lll
-		{MustHexDecodeString("0x03cd00000000000000000000000000000000000000000000000000000000000000"), testExtrinsicStatus4}, //nolint:lll
-		{MustHexDecodeString("0x040c10546869730869732462726f616463617374"), testExtrinsicStatus5},
+		{MustHexDecodeString("0x03ab00000000000000000000000000000000000000000000000000000000000000"), testExtrinsicStatus3}, //nolint:lll
+		{MustHexDecodeString("0x04cd00000000000000000000000000000000000000000000000000000000000000"), testExtrinsicStatus4}, //nolint:lll
+		{MustHexDecodeString("0x020c10546869730869732462726f616463617374"), testExtrinsicStatus5},
 		{[]byte{0x05}, testExtrinsicStatus6},
 		{[]byte{0x06}, testExtrinsicStatus7},
 	})


### PR DESCRIPTION
Updates `types.ExtrinsicStatus` to latest Substrate implementation found here: 

https://github.com/paritytech/substrate/blob/8c672e107789ed10973d937ba8cac245404377e2/primitives/transaction-pool/src/pool.rs#L106-L129