### PR TITLE
JSON-RPC subscription ID is a string in latest Substrate.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ git:
 notifications:
   email: false
 
-go_import_path: github.com/centrifuge/go-substrate-rpc-client
+go_import_path: github.com/Snowfork/go-substrate-rpc-client
 
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,8 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 WORKDIR $GOPATH
 
-RUN mkdir -p $GOPATH/src/github.com/centrifuge/go-substrate-rpc-client
-WORKDIR $GOPATH/src/github.com/centrifuge/go-substrate-rpc-client
+RUN mkdir -p $GOPATH/src/github.com/Snowfork/go-substrate-rpc-client
+WORKDIR $GOPATH/src/github.com/Snowfork/go-substrate-rpc-client
 COPY . .
 
 # Ensuring Subkey is available

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test-dockerized: 		## runs all tests in a docker container against the Substrate
 test-e2e-deployed: export RPC_URL?=wss://serinus-5.kusama.network
 test-e2e-deployed: 		## runs only end-to-end (e2e) tests against a deployed testnet (defaults to Kusama CC2 (wss://serinus-5.kusama.network) if RPC_URL is not set)
 	@docker build . -t gsrpc-test
-	@docker run --rm -e RPC_URL -e TEST_PRIV_KEY gsrpc-test go test -v github.com/centrifuge/go-substrate-rpc-client/teste2e
+	@docker run --rm -e RPC_URL -e TEST_PRIV_KEY gsrpc-test go test -v github.com/Snowfork/go-substrate-rpc-client/teste2e
 
 run-substrate-docker: 		## runs the Substrate 1.0 Default Docker image, this can be used to run the tests
 	docker run -p 9933:9933 -p 9944:9944 -p 30333:30333 parity/substrate:latest-v1.0 --dev --rpc-external --ws-external

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Go Substrate RPC Client (GSRPC)
 
 [![License: Apache v2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![GoDoc Reference](https://godoc.org/github.com/centrifuge/go-substrate-rpc-client?status.svg)](https://godoc.org/github.com/centrifuge/go-substrate-rpc-client)
+[![GoDoc Reference](https://godoc.org/github.com/Snowfork/go-substrate-rpc-client?status.svg)](https://godoc.org/github.com/Snowfork/go-substrate-rpc-client)
 [![Build Status](https://travis-ci.com/centrifuge/go-substrate-rpc-client.svg?branch=master)](https://travis-ci.com/centrifuge/go-substrate-rpc-client)
 [![codecov](https://codecov.io/gh/centrifuge/go-substrate-rpc-client/branch/master/graph/badge.svg)](https://codecov.io/gh/centrifuge/go-substrate-rpc-client)
-[![Go Report Card](https://goreportcard.com/badge/github.com/centrifuge/go-substrate-rpc-client)](https://goreportcard.com/report/github.com/centrifuge/go-substrate-rpc-client)
+[![Go Report Card](https://goreportcard.com/badge/github.com/Snowfork/go-substrate-rpc-client)](https://goreportcard.com/report/github.com/Snowfork/go-substrate-rpc-client)
 
 Substrate RPC client in Go. It provides APIs and types around Polkadot and any Substrate-based chain RPC calls.
 This client is modelled after [polkadot-js/api](https://github.com/polkadot-js/api).
@@ -15,7 +15,7 @@ This package is feature complete, but it is relatively new and might still conta
 
 ## Documentation & Usage Examples
 
-Please refer to https://godoc.org/github.com/centrifuge/go-substrate-rpc-client
+Please refer to https://godoc.org/github.com/Snowfork/go-substrate-rpc-client
 
 ## Contributing
 

--- a/blake2b/blake2b.go
+++ b/blake2b/blake2b.go
@@ -1,0 +1,71 @@
+// Package blake2b is a thin wrapper over golang.org/x/crypto/blake2b,
+// and additionally provides a BLAKE2b-128-concat hashing algorithm.
+package blake2b
+
+import (
+	"hash"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+// State for the blake2b_128_concat hasher
+type concatState struct {
+	// the underlying blake2b_128 hasher
+	hasher hash.Hash
+
+	// the key we need to append to the finalized hash digest (see Sum())
+	key []byte
+}
+
+func (s *concatState) Write(p []byte) (n int, err error) {
+	// save the key for later use in Sum()
+	s.key = append(s.key, p...)
+
+	return s.hasher.Write(p)
+}
+
+func (s *concatState) Sum(b []byte) []byte {
+	// append key to final hash digest
+	return append(s.hasher.Sum(b), s.key...)
+}
+
+func (s *concatState) Reset() {
+	s.key = nil
+	s.hasher.Reset()
+}
+
+func (s *concatState) Size() int {
+	return s.hasher.Size() + len(s.key)
+}
+
+func (s *concatState) BlockSize() int {
+	return s.hasher.BlockSize()
+}
+
+// New128Concat returns a new hash.Hash computing the BLAKE2b-128-concat checksum. A non-nil
+// key turns the hash into a MAC. The key must be between zero and 64 bytes long.
+func New128Concat(key []byte) (hash.Hash, error) {
+	inner, err := blake2b.New(16, key)
+	if err != nil {
+		return nil, err
+	}
+
+	hasher := concatState{
+		hasher: inner,
+		key:    key,
+	}
+
+	return &hasher, nil
+}
+
+// New128 returns a new hash.Hash computing the BLAKE2b-128 checksum. A non-nil
+// key turns the hash into a MAC. The key must be between zero and 64 bytes long.
+func New128(key []byte) (hash.Hash, error) {
+	return blake2b.New(16, key)
+}
+
+// New256 returns a new hash.Hash computing the BLAKE2b-256 checksum. A non-nil
+// key turns the hash into a MAC. The key must be between zero and 64 bytes long.
+func New256(key []byte) (hash.Hash, error) {
+	return blake2b.New256(key)
+}

--- a/blake2b/blake2b_test.go
+++ b/blake2b/blake2b_test.go
@@ -1,0 +1,64 @@
+package blake2b_test
+
+import (
+	"testing"
+
+	. "github.com/Snowfork/go-substrate-rpc-client/blake2b"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_128Concat(t *testing.T) {
+	key := []byte("abc")
+
+	h128, _ := New128(nil)
+	h128.Write(key)
+	h128.Write(key)
+	h128Concat, _ := New128Concat(nil)
+	h128Concat.Write(key)
+	h128Concat.Write(key)
+
+	assert.Equal(t, append(h128.Sum(nil), append(key, key...)...), h128Concat.Sum(nil))
+}
+
+func Test_128Concat_MAC(t *testing.T) {
+	key := []byte("abc")
+
+	h128, _ := New128(key)
+	h128Concat, _ := New128Concat(key)
+
+	assert.Equal(t, append(h128.Sum(nil), key...), h128Concat.Sum(nil))
+}
+
+func Test_128Concat_Size(t *testing.T) {
+	key := []byte("abc")
+
+	h128, _ := New128(nil)
+	h128.Write(key)
+
+	h128Concat, _ := New128Concat(nil)
+	h128Concat.Write(key)
+
+	assert.Equal(t, h128.Size()+len(key), h128Concat.Size())
+}
+
+func Test_128Concat_Reset(t *testing.T) {
+	key := []byte("abc")
+
+	h128, _ := New128(nil)
+	h128Concat, _ := New128Concat(nil)
+	h128Concat.Write(key)
+
+	h128Concat.Reset()
+
+	assert.Equal(t, h128.Sum(nil), h128Concat.Sum(nil))
+}
+
+func Test_128Concat_BlockSize(t *testing.T) {
+	key := []byte("abc")
+
+	h128, _ := New128(nil)
+	h128Concat, _ := New128Concat(nil)
+	h128Concat.Write(key)
+
+	assert.Equal(t, h128.BlockSize(), h128Concat.BlockSize())
+}

--- a/client/client.go
+++ b/client/client.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"log"
 
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
+	gethrpc "github.com/Snowfork/go-substrate-rpc-client/gethrpc"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 type Client interface {

--- a/doc.go
+++ b/doc.go
@@ -36,15 +36,15 @@ In order to sign extrinsics, you need to have [subkey](https://github.com/parity
 
 Types
 
-The package [types](https://godoc.org/github.com/centrifuge/go-substrate-rpc-client/types/) exports a number
+The package [types](https://godoc.org/github.com/Snowfork/go-substrate-rpc-client/types/) exports a number
 of useful basic types including functions for encoding and decoding them.
 
 To use your own custom types, you can simply create structs and arrays composing those basic types. Here are some
 examples using composition of a mix of these basic and builtin Go types:
 
-1. Vectors, lists, series, sets, arrays, slices: https://godoc.org/github.com/centrifuge/go-substrate-rpc-client/types/#example_Vec_simple
+1. Vectors, lists, series, sets, arrays, slices: https://godoc.org/github.com/Snowfork/go-substrate-rpc-client/types/#example_Vec_simple
 
-2. Structs: https://godoc.org/github.com/centrifuge/go-substrate-rpc-client/types/#example_Struct_simple
+2. Structs: https://godoc.org/github.com/Snowfork/go-substrate-rpc-client/types/#example_Struct_simple
 
 There are some caveats though that you should be aware of:
 
@@ -56,6 +56,6 @@ methods that implement the Encodeable/Decodeable interfaces. Examples for that a
 types, you can find reference implementations of those here: types/enum_test.go , types/tuple_test.go and
 types/vec_any_test.go
 
-For more information about the types sub-package, see https://godoc.org/github.com/centrifuge/go-substrate-rpc-client/types
+For more information about the types sub-package, see https://godoc.org/github.com/Snowfork/go-substrate-rpc-client/types
 */
 package gsrpc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - RPC_URL=ws://172.42.0.2:9944
       - TEST_PRIV_KEY=//Alice
     volumes:
-      - "$PWD/shared:/go/src/github.com/centrifuge/go-substrate-rpc-client/shared"
+      - "$PWD/shared:/go/src/github.com/Snowfork/go-substrate-rpc-client/shared"
 networks:
   gsrpc-network:
     ipam:

--- a/gethrpc/handler.go
+++ b/gethrpc/handler.go
@@ -282,9 +282,10 @@ func (h *handler) handleResponse(msg *jsonrpcMessage) {
 		op.err = msg.Error
 		return
 	}
-	var subid int
+	var subid string
+
 	if op.err = json.Unmarshal(msg.Result, &subid); op.err == nil {
-		op.sub.subid = fmt.Sprintf("%v", subid)
+		op.sub.subid = subid
 		go op.sub.start()
 		h.clientSubs[op.sub.subid] = op.sub
 	}

--- a/gethrpc/json.go
+++ b/gethrpc/json.go
@@ -39,7 +39,7 @@ const (
 var null = json.RawMessage("null")
 
 type subscriptionResult struct {
-	ID     int             `json:"subscription"`
+	ID     string          `json:"subscription"`
 	Result json.RawMessage `json:"result,omitempty"`
 }
 

--- a/gethrpc/subscription.go
+++ b/gethrpc/subscription.go
@@ -168,7 +168,7 @@ func (n *Notifier) activate() error {
 }
 
 func (n *Notifier) send(sub *Subscription, data json.RawMessage) error {
-	params, _ := json.Marshal(&subscriptionResult{ID: int(sub.ID), Result: data})
+	params, _ := json.Marshal(&subscriptionResult{ID: string(sub.ID), Result: data})
 	ctx := context.Background()
 	return n.h.conn.Write(ctx, &jsonrpcMessage{
 		Version: vsn,

--- a/main.go
+++ b/main.go
@@ -17,8 +17,8 @@
 package gsrpc
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/rpc"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/rpc"
 )
 
 type SubstrateAPI struct {

--- a/main_test.go
+++ b/main_test.go
@@ -21,10 +21,10 @@ import (
 	"math/big"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	gsrpc "github.com/Snowfork/go-substrate-rpc-client"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
+	"github.com/Snowfork/go-substrate-rpc-client/signature"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func Example_simpleConnect() {

--- a/rpc/author/author.go
+++ b/rpc/author/author.go
@@ -16,7 +16,7 @@
 
 package author
 
-import "github.com/centrifuge/go-substrate-rpc-client/client"
+import "github.com/Snowfork/go-substrate-rpc-client/client"
 
 // Author exposes methods for authoring of network items
 type Author struct {

--- a/rpc/author/author_test.go
+++ b/rpc/author/author_test.go
@@ -20,8 +20,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/rpcmocksrv"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/rpcmocksrv"
 )
 
 var author *Author

--- a/rpc/author/pending_extrinsics.go
+++ b/rpc/author/pending_extrinsics.go
@@ -17,7 +17,7 @@
 package author
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // PendingExtrinsics returns all pending extrinsics, potentially grouped by sender

--- a/rpc/author/pending_extrinsics_test.go
+++ b/rpc/author/pending_extrinsics_test.go
@@ -19,7 +19,7 @@ package author
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/author/submit_and_watch_extrinsic.go
+++ b/rpc/author/submit_and_watch_extrinsic.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
+	gethrpc "github.com/Snowfork/go-substrate-rpc-client/gethrpc"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // ExtrinsicStatusSubscription is a subscription established through one of the Client's subscribe methods.

--- a/rpc/author/submit_extrinsic.go
+++ b/rpc/author/submit_extrinsic.go
@@ -16,7 +16,7 @@
 
 package author
 
-import "github.com/centrifuge/go-substrate-rpc-client/types"
+import "github.com/Snowfork/go-substrate-rpc-client/types"
 
 // SubmitExtrinsic will submit a fully formatted extrinsic for block inclusion
 func (a *Author) SubmitExtrinsic(xt types.Extrinsic) (types.Hash, error) {

--- a/rpc/author/submit_extrinsic_test.go
+++ b/rpc/author/submit_extrinsic_test.go
@@ -19,7 +19,7 @@ package author
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/chain/chain.go
+++ b/rpc/chain/chain.go
@@ -17,7 +17,7 @@
 package chain
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
 )
 
 // Chain exposes methods for retrieval of chain data

--- a/rpc/chain/chain_test.go
+++ b/rpc/chain/chain_test.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/rpcmocksrv"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/rpcmocksrv"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 var chain *Chain

--- a/rpc/chain/get_block.go
+++ b/rpc/chain/get_block.go
@@ -17,8 +17,8 @@
 package chain
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetBlock returns the header and body of the relay chain block with the given hash

--- a/rpc/chain/get_block_hash.go
+++ b/rpc/chain/get_block_hash.go
@@ -17,7 +17,7 @@
 package chain
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetBlockHash returns the block hash for a specific block height

--- a/rpc/chain/get_block_hash_test.go
+++ b/rpc/chain/get_block_hash_test.go
@@ -19,7 +19,7 @@ package chain
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/chain/get_finalized_head.go
+++ b/rpc/chain/get_finalized_head.go
@@ -17,7 +17,7 @@
 package chain
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetFinalizedHead returns the hash of the last finalized block in the canon chain

--- a/rpc/chain/get_finalized_head_test.go
+++ b/rpc/chain/get_finalized_head_test.go
@@ -19,7 +19,7 @@ package chain
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/chain/get_header.go
+++ b/rpc/chain/get_header.go
@@ -17,8 +17,8 @@
 package chain
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetHeader retrieves the header for the specific block

--- a/rpc/chain/subscribe_finalized_heads.go
+++ b/rpc/chain/subscribe_finalized_heads.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
+	gethrpc "github.com/Snowfork/go-substrate-rpc-client/gethrpc"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // FinalizedHeadsSubscription is a subscription established through one of the Client's subscribe methods.

--- a/rpc/chain/subscribe_new_heads.go
+++ b/rpc/chain/subscribe_new_heads.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
+	gethrpc "github.com/Snowfork/go-substrate-rpc-client/gethrpc"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // NewHeadsSubscription is a subscription established through one of the Client's subscribe methods.

--- a/rpc/main.go
+++ b/rpc/main.go
@@ -17,12 +17,12 @@
 package rpc
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/rpc/author"
-	"github.com/centrifuge/go-substrate-rpc-client/rpc/chain"
-	"github.com/centrifuge/go-substrate-rpc-client/rpc/state"
-	"github.com/centrifuge/go-substrate-rpc-client/rpc/system"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/rpc/author"
+	"github.com/Snowfork/go-substrate-rpc-client/rpc/chain"
+	"github.com/Snowfork/go-substrate-rpc-client/rpc/state"
+	"github.com/Snowfork/go-substrate-rpc-client/rpc/system"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 type RPC struct {

--- a/rpc/state/get_child_keys.go
+++ b/rpc/state/get_child_keys.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetChildKeys retreives the keys with the given prefix of a specific child storage

--- a/rpc/state/get_child_keys_test.go
+++ b/rpc/state/get_child_keys_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/get_child_storage.go
+++ b/rpc/state/get_child_storage.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetChildStorage retreives the child storage for a key and decodes them into the provided interface. Ok is true if the

--- a/rpc/state/get_child_storage_hash.go
+++ b/rpc/state/get_child_storage_hash.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetChildStorageHash retreives the child storage hash for the given key

--- a/rpc/state/get_child_storage_hash_test.go
+++ b/rpc/state/get_child_storage_hash_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/get_child_storage_size.go
+++ b/rpc/state/get_child_storage_size.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetChildStorageSize retreives the child storage size for the given key

--- a/rpc/state/get_child_storage_test.go
+++ b/rpc/state/get_child_storage_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/get_keys.go
+++ b/rpc/state/get_keys.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetKeys retreives the keys with the given prefix

--- a/rpc/state/get_keys_test.go
+++ b/rpc/state/get_keys_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/get_metadata.go
+++ b/rpc/state/get_metadata.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetMetadata returns the metadata at the given block

--- a/rpc/state/get_runtime_version.go
+++ b/rpc/state/get_runtime_version.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetRuntimeVersion returns the runtime version at the given block

--- a/rpc/state/get_storage.go
+++ b/rpc/state/get_storage.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetStorage retreives the stored data and decodes them into the provided interface. Ok is true if the value is not

--- a/rpc/state/get_storage_hash.go
+++ b/rpc/state/get_storage_hash.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetStorageHash retreives the storage hash for the given key

--- a/rpc/state/get_storage_hash_test.go
+++ b/rpc/state/get_storage_hash_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/get_storage_size.go
+++ b/rpc/state/get_storage_size.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // GetStorageSize retreives the storage size for the given key

--- a/rpc/state/get_storage_size_test.go
+++ b/rpc/state/get_storage_size_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/get_storage_test.go
+++ b/rpc/state/get_storage_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/query_storage.go
+++ b/rpc/state/query_storage.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // QueryStorage queries historical storage entries (by key) starting from a start block until an end block

--- a/rpc/state/query_storage_test.go
+++ b/rpc/state/query_storage_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/state.go
+++ b/rpc/state/state.go
@@ -16,7 +16,7 @@
 
 package state
 
-import "github.com/centrifuge/go-substrate-rpc-client/client"
+import "github.com/Snowfork/go-substrate-rpc-client/client"
 
 // State exposes methods for querying state
 type State struct {

--- a/rpc/state/state_test.go
+++ b/rpc/state/state_test.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/rpcmocksrv"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/rpcmocksrv"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 var state *State

--- a/rpc/state/subscribe_runtime_version.go
+++ b/rpc/state/subscribe_runtime_version.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
+	gethrpc "github.com/Snowfork/go-substrate-rpc-client/gethrpc"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // RuntimeVersionSubscription is a subscription established through one of the Client's subscribe methods.

--- a/rpc/state/subscribe_storage.go
+++ b/rpc/state/subscribe_storage.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
+	gethrpc "github.com/Snowfork/go-substrate-rpc-client/gethrpc"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // StorageSubscription is a subscription established through one of the Client's subscribe methods.

--- a/rpc/system/chain.go
+++ b/rpc/system/chain.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // Chain retrieves the chain

--- a/rpc/system/health.go
+++ b/rpc/system/health.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // Health retrieves the health status of the connected node

--- a/rpc/system/name.go
+++ b/rpc/system/name.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // Name retrieves the node name

--- a/rpc/system/network_state.go
+++ b/rpc/system/network_state.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // NetworkState retrieves the current state of the network

--- a/rpc/system/peers.go
+++ b/rpc/system/peers.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // Peers retrieves the currently connected peers

--- a/rpc/system/properties.go
+++ b/rpc/system/properties.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // Properties retrieves a custom set of properties as a JSON object, defined in the chain spec

--- a/rpc/system/system.go
+++ b/rpc/system/system.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
 )
 
 // System exposes methods for retrieval of system data

--- a/rpc/system/system_test.go
+++ b/rpc/system/system_test.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/rpcmocksrv"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/client"
+	"github.com/Snowfork/go-substrate-rpc-client/rpcmocksrv"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 var system *System

--- a/rpc/system/version.go
+++ b/rpc/system/version.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // Version retrieves the version of the node

--- a/rpcmocksrv/server.go
+++ b/rpcmocksrv/server.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"time"
 
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
+	gethrpc "github.com/Snowfork/go-substrate-rpc-client/gethrpc"
 )
 
 type Server struct {

--- a/rpcmocksrv/server_test.go
+++ b/rpcmocksrv/server_test.go
@@ -19,7 +19,7 @@ package rpcmocksrv
 import (
 	"testing"
 
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
+	gethrpc "github.com/Snowfork/go-substrate-rpc-client/gethrpc"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/signature/signature.go
+++ b/signature/signature.go
@@ -38,7 +38,7 @@ type KeyringPair struct {
 	PublicKey []byte
 }
 
-var rePubKey = regexp.MustCompile(`Public key \(hex\): 0x([a-f0-9]*)\n`)
+var rePubKey = regexp.MustCompile(`Public key \(hex\):\s+0x([a-f0-9]*)\n`)
 var reAddressOld = regexp.MustCompile(`Address \(SS58\): ([a-zA-Z0-9]*)\n`)
 var reAddressNew = regexp.MustCompile(`SS58 Address:\s+([a-zA-Z0-9]*)\n`)
 

--- a/signature/signature_test.go
+++ b/signature/signature_test.go
@@ -20,8 +20,8 @@ import (
 	"crypto/rand"
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/signature"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/signature"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teste2e/author_submit_and_watch_extrinsic_test.go
+++ b/teste2e/author_submit_and_watch_extrinsic_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	gsrpc "github.com/Snowfork/go-substrate-rpc-client"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
+	"github.com/Snowfork/go-substrate-rpc-client/signature"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teste2e/author_submit_and_watch_extrinsic_test.go
+++ b/teste2e/author_submit_and_watch_extrinsic_test.go
@@ -95,6 +95,7 @@ func TestAuthor_SubmitAndWatchExtrinsic(t *testing.T) {
 		GenesisHash: genesisHash,
 		Nonce:       types.NewUCompactFromUInt(uint64(nonce)),
 		SpecVersion: rv.SpecVersion,
+		TxVersion:   1,
 		Tip:         types.NewUCompactFromUInt(0),
 	}
 

--- a/teste2e/author_submit_extrinsic_test.go
+++ b/teste2e/author_submit_extrinsic_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	gsrpc "github.com/Snowfork/go-substrate-rpc-client"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
+	"github.com/Snowfork/go-substrate-rpc-client/signature"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestChain_Events(t *testing.T) {

--- a/teste2e/author_submit_extrinsic_test.go
+++ b/teste2e/author_submit_extrinsic_test.go
@@ -138,6 +138,7 @@ func TestChain_SubmitExtrinsic(t *testing.T) {
 			GenesisHash: genesisHash,
 			Nonce:       types.NewUCompactFromUInt(uint64(nonce + i)),
 			SpecVersion: rv.SpecVersion,
+			TxVersion:   1,
 			Tip:         types.NewUCompactFromUInt(0),
 		}
 
@@ -175,4 +176,99 @@ func TestChain_SubmitExtrinsic(t *testing.T) {
 
 		time.Sleep(1 * time.Second)
 	}
+}
+
+func TestChain_SubmitExtrinsic_Simple(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping end-to-end test in short mode.")
+	}
+
+	from, ok := signature.LoadKeyringPairFromEnv()
+	if !ok {
+		t.Skip("skipping end-to-end that requires a private key because TEST_PRIV_KEY is not set or empty")
+	}
+
+	api, err := gsrpc.NewSubstrateAPI(config.Default().RPCURL)
+	if err != nil {
+		panic(err)
+	}
+
+	meta, err := api.RPC.State.GetMetadataLatest()
+	if err != nil {
+		panic(err)
+	}
+
+	bob, err := types.NewAddressFromHexAccountID("0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48")
+	if err != nil {
+		panic(err)
+	}
+
+	c, err := types.NewCall(meta, "Balances.transfer", bob, types.NewUCompactFromUInt(6969))
+	if err != nil {
+		panic(err)
+	}
+
+	ext := types.NewExtrinsic(c)
+
+	era := types.ExtrinsicEra{IsMortalEra: false}
+
+	genesisHash, err := api.RPC.Chain.GetBlockHash(0)
+	if err != nil {
+		panic(err)
+	}
+
+	rv, err := api.RPC.State.GetRuntimeVersionLatest()
+	if err != nil {
+		panic(err)
+	}
+
+	key, err := types.CreateStorageKey(meta, "System", "Account", from.PublicKey, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	var accountInfo types.AccountInfo
+	ok, err = api.RPC.State.GetStorageLatest(key, &accountInfo)
+	if err != nil || !ok {
+		panic(err)
+	}
+
+	nonce := uint32(accountInfo.Nonce)
+
+	o := types.SignatureOptions{
+		BlockHash:   genesisHash,
+		Era:         era,
+		GenesisHash: genesisHash,
+		Nonce:       types.NewUCompactFromUInt(uint64(nonce)),
+		SpecVersion: rv.SpecVersion,
+		TxVersion:   1,
+		Tip:         types.NewUCompactFromUInt(0),
+	}
+
+	extI := ext
+
+	err = extI.Sign(from, o)
+	if err != nil {
+		panic(err)
+	}
+
+	extEnc, err := types.EncodeToHexString(extI)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Extrinsic: %#v\n", extEnc)
+
+	_, err = api.RPC.Author.SubmitExtrinsic(extI)
+	if err != nil {
+		panic(err)
+	}
+
+	xts, err := api.RPC.Author.PendingExtrinsics()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Pending extrinsics: %#v\n", xts)
+
 }

--- a/teste2e/chain_subscribe_finalized_heads_test.go
+++ b/teste2e/chain_subscribe_finalized_heads_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
+	gsrpc "github.com/Snowfork/go-substrate-rpc-client"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teste2e/chain_subscribe_new_heads_test.go
+++ b/teste2e/chain_subscribe_new_heads_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
+	gsrpc "github.com/Snowfork/go-substrate-rpc-client"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teste2e/main_test.go
+++ b/teste2e/main_test.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"testing"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	gsrpc "github.com/Snowfork/go-substrate-rpc-client"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teste2e/state_subscribe_runtime_version_test.go
+++ b/teste2e/state_subscribe_runtime_version_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
+	gsrpc "github.com/Snowfork/go-substrate-rpc-client"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teste2e/state_subscribe_storage_test.go
+++ b/teste2e/state_subscribe_storage_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	gsrpc "github.com/Snowfork/go-substrate-rpc-client"
+	"github.com/Snowfork/go-substrate-rpc-client/config"
+	"github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/account_id_test.go
+++ b/types/account_id_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestAccountID_EncodeDecode(t *testing.T) {

--- a/types/account_index_test.go
+++ b/types/account_index_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestAccountIndex_EncodeDecode(t *testing.T) {

--- a/types/account_info_test.go
+++ b/types/account_info_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestAccountInfoV4_EncodeDecode(t *testing.T) {

--- a/types/address.go
+++ b/types/address.go
@@ -19,7 +19,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // Address is a wrapper around an AccountId or an AccountIndex. It is encoded with a prefix in case of an AccountID.

--- a/types/address_test.go
+++ b/types/address_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/binary"
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestAddress_EncodeDecode(t *testing.T) {

--- a/types/bool_test.go
+++ b/types/bool_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestBool_EncodeDecode(t *testing.T) {

--- a/types/bytes.go
+++ b/types/bytes.go
@@ -19,7 +19,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // Bytes represents byte slices. Bytes has a variable length, it is encoded with a scale prefix

--- a/types/bytes_test.go
+++ b/types/bytes_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestBytes_EncodeDecode(t *testing.T) {

--- a/types/chain_properties.go
+++ b/types/chain_properties.go
@@ -17,7 +17,7 @@
 package types
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // ChainProperties contains the SS58 format, the token decimals and the token symbol

--- a/types/chain_properties_test.go
+++ b/types/chain_properties_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 var testChainProperties1 = ChainProperties{}

--- a/types/codec.go
+++ b/types/codec.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/types/data.go
+++ b/types/data.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // Data is a raw data structure, containing raw bytes that are not decoded/encoded (without any length encoding).

--- a/types/data_test.go
+++ b/types/data_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/digest_item.go
+++ b/types/digest_item.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/Snowfork/go-substrate-rpc-client/scale"
 
 // DigestItem specifies the item in the logs of a digest
 type DigestItem struct {

--- a/types/digest_item_test.go
+++ b/types/digest_item_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 var testDigestItem1 = DigestItem{IsOther: true, AsOther: NewBytes([]byte{0xab})}

--- a/types/digest_of_test.go
+++ b/types/digest_of_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestDigestOf_EncodeDecode(t *testing.T) {

--- a/types/digest_test.go
+++ b/types/digest_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestDigest_EncodeDecode(t *testing.T) {

--- a/types/event_record.go
+++ b/types/event_record.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 	"github.com/ethereum/go-ethereum/log"
 )
 

--- a/types/event_record_test.go
+++ b/types/event_record_test.go
@@ -21,7 +21,7 @@ import (
 	"math/big"
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/events.go
+++ b/types/events.go
@@ -19,7 +19,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // EventBalancesEndowed is emitted when an account is created with some free balance

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/example_enum_test.go
+++ b/types/example_enum_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // PhaseEnum is an enum example. Since Go has no enums, it is implemented as a struct with flags for each

--- a/types/example_struct_test.go
+++ b/types/example_struct_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"fmt"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func ExampleExampleStruct() {

--- a/types/example_tuple_test.go
+++ b/types/example_tuple_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"fmt"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 
 	"golang.org/x/crypto/blake2b"
 )

--- a/types/example_vec_any_test.go
+++ b/types/example_vec_any_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // MyVal is a custom type that is used to hold arbitrarily encoded data. In this example, we encode uint8s with a 0x00

--- a/types/example_vec_test.go
+++ b/types/example_vec_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func ExampleExampleVec_simple() {

--- a/types/extrinsic.go
+++ b/types/extrinsic.go
@@ -134,12 +134,13 @@ func (e *Extrinsic) Sign(signer signature.KeyringPair, o SignatureOptions) error
 		era = ExtrinsicEra{IsImmortalEra: true}
 	}
 
-	payload := ExtrinsicPayloadV3{
+	payload := ExtrinsicPayloadV4{
 		Method:      mb,
 		Era:         era,
 		Nonce:       o.Nonce,
 		Tip:         o.Tip,
 		SpecVersion: o.SpecVersion,
+		TxVersion:   o.TxVersion,
 		GenesisHash: o.GenesisHash,
 		BlockHash:   o.BlockHash,
 	}

--- a/types/extrinsic.go
+++ b/types/extrinsic.go
@@ -24,8 +24,8 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/signature"
 )
 
 const (

--- a/types/extrinsic_era.go
+++ b/types/extrinsic_era.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/Snowfork/go-substrate-rpc-client/scale"
 
 // ExtrinsicEra indicates either a mortal or immortal extrinsic
 type ExtrinsicEra struct {

--- a/types/extrinsic_era_test.go
+++ b/types/extrinsic_era_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/extrinsic_payload.go
+++ b/types/extrinsic_payload.go
@@ -19,8 +19,8 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/signature"
 )
 
 // ExtrinsicPayloadV3 is a signing payload for an Extrinsic. For the final encoding, it is variable length based on

--- a/types/extrinsic_payloadV3.go
+++ b/types/extrinsic_payloadV3.go
@@ -27,7 +27,7 @@ import (
 // the contents included. Note that `BytesBare` is absolutely critical – we don't want the method (Bytes)
 // to have the length prefix included. This means that the data-as-signed is un-decodable,
 // but is also doesn't need the extra information, only the pure data (and is not decoded)
-// ... The same applies to V1 & V1, if we have a V4, carry move this comment to latest
+// ... The same applies to V1-V2, if we have a V4, carry move this comment to latest
 type ExtrinsicPayloadV3 struct {
 	Method      BytesBare
 	Era         ExtrinsicEra // extra via system::CheckEra

--- a/types/extrinsic_payloadV4.go
+++ b/types/extrinsic_payloadV4.go
@@ -1,0 +1,102 @@
+// Go Substrate RPC Client (GSRPC) provides APIs and types around Polkadot and any Substrate-based chain RPC calls
+//
+// Copyright 2019 Centrifuge GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"fmt"
+
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/signature"
+)
+
+// ExtrinsicPayloadV4 is a signing payload for an Extrinsic. For the final encoding, it is variable length based on
+// the contents included. Note that `BytesBare` is absolutely critical – we don't want the method (Bytes)
+// to have the length prefix included. This means that the data-as-signed is un-decodable,
+// but is also doesn't need the extra information, only the pure data (and is not decoded)
+// ... The same applies to V1-V3, if we have a V5, carry move this comment to latest
+type ExtrinsicPayloadV4 struct {
+	Method      BytesBare
+	Era         ExtrinsicEra // extra via system::CheckEra
+	Nonce       UCompact     // extra via system::CheckNonce (Compact<Index> where Index is u32)
+	Tip         UCompact     // extra via balances::TakeFees (Compact<Balance> where Balance is u128)
+	SpecVersion U32          // additional via system::CheckVersion
+	TxVersion   U32          // additional via system::CheckTxVersion
+	GenesisHash Hash         // additional via system::CheckGenesis
+	BlockHash   Hash         // additional via system::CheckEra
+}
+
+// Sign the extrinsic payload with the given derivation path
+func (e ExtrinsicPayloadV4) Sign(signer signature.KeyringPair) (Signature, error) {
+	b, err := EncodeToBytes(e)
+	if err != nil {
+		return Signature{}, err
+	}
+
+	sig, err := signature.Sign(b, signer.URI)
+	return NewSignature(sig), err
+}
+
+// Encode implements encoding for ExtrinsicPayloadV4, which just unwraps the bytes of ExtrinsicPayloadV4 without
+// adding a compact length prefix
+func (e ExtrinsicPayloadV4) Encode(encoder scale.Encoder) error {
+	err := encoder.Encode(e.Method)
+	if err != nil {
+		return err
+	}
+
+	err = encoder.Encode(e.Era)
+	if err != nil {
+		return err
+	}
+
+	err = encoder.Encode(e.Nonce)
+	if err != nil {
+		return err
+	}
+
+	err = encoder.Encode(e.Tip)
+	if err != nil {
+		return err
+	}
+
+	err = encoder.Encode(e.SpecVersion)
+	if err != nil {
+		return err
+	}
+
+	err = encoder.Encode(e.TxVersion)
+	if err != nil {
+		return err
+	}
+
+	err = encoder.Encode(e.GenesisHash)
+	if err != nil {
+		return err
+	}
+
+	err = encoder.Encode(e.BlockHash)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Decode does nothing and always returns an error. ExtrinsicPayloadV3 is only used for encoding, not for decoding
+func (e *ExtrinsicPayloadV4) Decode(decoder scale.Decoder) error {
+	return fmt.Errorf("decoding of ExtrinsicPayloadV4 is not supported")
+}

--- a/types/extrinsic_payload_test.go
+++ b/types/extrinsic_payload_test.go
@@ -19,8 +19,8 @@ package types_test
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/signature"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/extrinsic_signature.go
+++ b/types/extrinsic_signature.go
@@ -37,6 +37,7 @@ type SignatureOptions struct {
 	Nonce       UCompact     // extra via system::CheckNonce (Compact<Index> where Index is u32)
 	Tip         UCompact     // extra via balances::TakeFees (Compact<Balance> where Balance is u128)
 	SpecVersion U32          // additional via system::CheckVersion
+	TxVersion   U32
 	GenesisHash Hash         // additional via system::CheckGenesis
 	BlockHash   Hash         // additional via system::CheckEra
 }

--- a/types/extrinsic_signature_test.go
+++ b/types/extrinsic_signature_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/extrinsic_status.go
+++ b/types/extrinsic_status.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // ExtrinsicStatus is an enum containing the result of an extrinsic submission

--- a/types/extrinsic_status_test.go
+++ b/types/extrinsic_status_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/extrinsic_test.go
+++ b/types/extrinsic_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/signature"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/hash_test.go
+++ b/types/hash_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 var hash20 = []byte{

--- a/types/header.go
+++ b/types/header.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 type Header struct {

--- a/types/header_test.go
+++ b/types/header_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 var exampleHeader = Header{

--- a/types/health_test.go
+++ b/types/health_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestHealth_EncodeDecode(t *testing.T) {

--- a/types/int.go
+++ b/types/int.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // I8 is a signed 8-bit integer

--- a/types/int_test.go
+++ b/types/int_test.go
@@ -20,7 +20,7 @@ import (
 	"math/big"
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/metadata.go
+++ b/types/metadata.go
@@ -19,7 +19,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 const MagicNumber uint32 = 0x6174656d

--- a/types/metadataV10.go
+++ b/types/metadataV10.go
@@ -22,9 +22,9 @@ import (
 	"hash"
 	"strings"
 
+	"github.com/Snowfork/go-substrate-rpc-client/blake2b"
 	"github.com/Snowfork/go-substrate-rpc-client/scale"
 	"github.com/Snowfork/go-substrate-rpc-client/xxhash"
-	"golang.org/x/crypto/blake2b"
 )
 
 // Modelled after packages/types/src/Metadata/v10/Metadata.ts
@@ -419,7 +419,7 @@ func (s StorageHasherV10) Encode(encoder scale.Encoder) error {
 func (s StorageHasherV10) HashFunc() (hash.Hash, error) {
 	// Blake2_128
 	if s.IsBlake2_128 {
-		return blake2b.New(128, nil)
+		return blake2b.New128(nil)
 	}
 
 	// Blake2_256
@@ -427,9 +427,9 @@ func (s StorageHasherV10) HashFunc() (hash.Hash, error) {
 		return blake2b.New256(nil)
 	}
 
-	// Blake2_256
-	if s.IsBlake2_128Concat { // TODO add support
-		return nil, errors.New("hash function type blake2_128concat not yet supported")
+	// Blake2_128Concat
+	if s.IsBlake2_128Concat {
+		return blake2b.New128Concat(nil)
 	}
 
 	// Twox128

--- a/types/metadataV10.go
+++ b/types/metadataV10.go
@@ -22,8 +22,8 @@ import (
 	"hash"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	"github.com/centrifuge/go-substrate-rpc-client/xxhash"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/xxhash"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/types/metadataV10_test.go
+++ b/types/metadataV10_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/metadataV11.go
+++ b/types/metadataV11.go
@@ -1,6 +1,6 @@
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/Snowfork/go-substrate-rpc-client/scale"
 
 // Modelled after packages/types/src/Metadata/v10/toV11.ts
 type MetadataV11 struct {

--- a/types/metadataV11_test.go
+++ b/types/metadataV11_test.go
@@ -3,7 +3,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/metadataV4.go
+++ b/types/metadataV4.go
@@ -22,8 +22,8 @@ import (
 	"hash"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	"github.com/centrifuge/go-substrate-rpc-client/xxhash"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/xxhash"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/types/metadataV4_test.go
+++ b/types/metadataV4_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/types/metadataV7.go
+++ b/types/metadataV7.go
@@ -21,8 +21,8 @@ import (
 	"hash"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	"github.com/centrifuge/go-substrate-rpc-client/xxhash"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/xxhash"
 )
 
 // Modelled after packages/types/src/Metadata/v7/Metadata.ts

--- a/types/metadataV7_test.go
+++ b/types/metadataV7_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 var exampleMetadataV7 = Metadata{

--- a/types/metadataV8.go
+++ b/types/metadataV8.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // Modelled after packages/types/src/Metadata/v8/Metadata.ts

--- a/types/metadataV8_test.go
+++ b/types/metadataV8_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/metadataV9.go
+++ b/types/metadataV9.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // Modelled after packages/types/src/Metadata/v9/Metadata.ts

--- a/types/metadataV9_test.go
+++ b/types/metadataV9_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/moment.go
+++ b/types/moment.go
@@ -21,7 +21,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 const (

--- a/types/moment_test.go
+++ b/types/moment_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestMoment_EncodeDecode(t *testing.T) {

--- a/types/multi_signature.go
+++ b/types/multi_signature.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/Snowfork/go-substrate-rpc-client/scale"
 
 // MultiSignature
 type MultiSignature struct {

--- a/types/multi_signature_test.go
+++ b/types/multi_signature_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 var testMultiSig1 = MultiSignature{IsEd25519: true, AsEd25519: NewSignature(hash64)}

--- a/types/network_state_test.go
+++ b/types/network_state_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestNetworkState_EncodeDecode(t *testing.T) {

--- a/types/null.go
+++ b/types/null.go
@@ -17,7 +17,7 @@
 package types
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // Null is a type that does not contain anything (apart from null)

--- a/types/null_test.go
+++ b/types/null_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestNull_EncodeDecode(t *testing.T) {

--- a/types/option_bool.go
+++ b/types/option_bool.go
@@ -19,7 +19,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // OptionBool is a structure that can store a Bool or a missing value

--- a/types/option_bool_test.go
+++ b/types/option_bool_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestOptionBool_EncodeDecode(t *testing.T) {

--- a/types/option_bytes.go
+++ b/types/option_bytes.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/Snowfork/go-substrate-rpc-client/scale"
 
 // OptionBytes is a structure that can store a Bytes or a missing value
 type OptionBytes struct {

--- a/types/option_bytes_test.go
+++ b/types/option_bytes_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestOptionBytes8_EncodeDecode(t *testing.T) {

--- a/types/option_hash.go
+++ b/types/option_hash.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/Snowfork/go-substrate-rpc-client/scale"
 
 // OptionH160 is a structure that can store a H160 or a missing value
 type OptionH160 struct {

--- a/types/option_hash_test.go
+++ b/types/option_hash_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestOptionH160_EncodeDecode(t *testing.T) {

--- a/types/option_int.go
+++ b/types/option_int.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/Snowfork/go-substrate-rpc-client/scale"
 
 // OptionI8 is a structure that can store a I8 or a missing value
 type OptionI8 struct {

--- a/types/option_int_test.go
+++ b/types/option_int_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestOptionI8_EncodeDecode(t *testing.T) {

--- a/types/option_uint.go
+++ b/types/option_uint.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/Snowfork/go-substrate-rpc-client/scale"
 
 // OptionU8 is a structure that can store a U8 or a missing value
 type OptionU8 struct {

--- a/types/option_uint_test.go
+++ b/types/option_uint_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestOptionU8_EncodeDecode(t *testing.T) {

--- a/types/origin.go
+++ b/types/origin.go
@@ -17,7 +17,7 @@
 package types
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // Origin is an internal-only value that will be ignored when encoding/decoding

--- a/types/origin_test.go
+++ b/types/origin_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 // newOrigin creates a new Origin type. This function is not exported by purpose – Origin should be ignored and not be

--- a/types/peer_info_test.go
+++ b/types/peer_info_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 var testPeerInfo = PeerInfo{

--- a/types/runtime_version.go
+++ b/types/runtime_version.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 type RuntimeVersion struct {

--- a/types/runtime_version_test.go
+++ b/types/runtime_version_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/signature_test.go
+++ b/types/signature_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestSignature_EncodeDecode(t *testing.T) {

--- a/types/signed_block_test.go
+++ b/types/signed_block_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/storage_change_set_test.go
+++ b/types/storage_change_set_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/storage_data_raw.go
+++ b/types/storage_data_raw.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // StorageDataRaw contains raw bytes that are not decoded/encoded.

--- a/types/storage_data_raw_test.go
+++ b/types/storage_data_raw_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/storage_key.go
+++ b/types/storage_key.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	"github.com/centrifuge/go-substrate-rpc-client/xxhash"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/xxhash"
 )
 
 // StorageKey represents typically hashed storage keys of the system.

--- a/types/storage_key_test.go
+++ b/types/storage_key_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/test_utils_test.go
+++ b/types/test_utils_test.go
@@ -22,8 +22,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/text_test.go
+++ b/types/text_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestString_EncodeDecode(t *testing.T) {

--- a/types/type_test.go
+++ b/types/type_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestType_EncodeDecode(t *testing.T) {

--- a/types/ucompact.go
+++ b/types/ucompact.go
@@ -19,7 +19,7 @@ package types
 import (
 	"math/big"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 type UCompact big.Int

--- a/types/uint.go
+++ b/types/uint.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
 )
 
 // U8 is an unsigned 8-bit integer

--- a/types/uint_test.go
+++ b/types/uint_test.go
@@ -21,8 +21,8 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/Snowfork/go-substrate-rpc-client/scale"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/usize_test.go
+++ b/types/usize_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestUSize_EncodeDecode(t *testing.T) {

--- a/types/weight_multiplier_test.go
+++ b/types/weight_multiplier_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestWeightMultiplier_EncodeDecode(t *testing.T) {

--- a/types/weight_test.go
+++ b/types/weight_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/Snowfork/go-substrate-rpc-client/types"
 )
 
 func TestWeight_EncodeDecode(t *testing.T) {

--- a/xxhash/xxhash_test.go
+++ b/xxhash/xxhash_test.go
@@ -19,7 +19,7 @@ package xxhash_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/xxhash"
+	. "github.com/Snowfork/go-substrate-rpc-client/xxhash"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
It is now an alphanumeric string rather than an integer. See below examples:

Subscription request:
```
{"jsonrpc":"2.0","id":3,"method":"state_subscribeStorage","params":[["0x26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7"]]}
```
Response with subscription ID:
```
{"jsonrpc":"2.0","result":"Fi0OGRHhayI77bgL","id":3}
```

published event with subscription ID `Fi0OGRHhayI77bgL`.
```
{"jsonrpc":"2.0","method":"state_storage","params":{"result":{"block":"0x6a410de4d58043cbfe4209fe48f9c88d1840cf37d1b6eea8294bc403cdb4c30d","changes":[["0x26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7","0x040000000000000080e36a0900000000020000"]]},"subscription":"Fi0OGRHhayI77bgL"}}
```
