### PR TITLE
Phase enum has new field Initialization

### DIFF
--- a/types/event_record.go
+++ b/types/event_record.go
@@ -315,6 +315,7 @@ type Phase struct {
 	IsApplyExtrinsic bool
 	AsApplyExtrinsic uint32
 	IsFinalization   bool
+	IsInitialization bool
 }
 
 func (p *Phase) Decode(decoder scale.Decoder) error {
@@ -328,6 +329,8 @@ func (p *Phase) Decode(decoder scale.Decoder) error {
 		err = decoder.Decode(&p.AsApplyExtrinsic)
 	} else if b == 1 {
 		p.IsFinalization = true
+	} else if b == 2 {
+		p.IsInitialization = true
 	}
 
 	if err != nil {
@@ -344,6 +347,8 @@ func (p Phase) Encode(encoder scale.Encoder) error {
 		err2 = encoder.Encode(p.AsApplyExtrinsic)
 	} else if p.IsFinalization {
 		err1 = encoder.PushByte(1)
+	} else if p.IsInitialization {
+		err1 = encoder.PushByte(2)
 	}
 
 	if err1 != nil {

--- a/types/event_record.go
+++ b/types/event_record.go
@@ -324,12 +324,13 @@ func (p *Phase) Decode(decoder scale.Decoder) error {
 		return err
 	}
 
-	if b == 0 {
+	switch b {
+	case 0:
 		p.IsApplyExtrinsic = true
 		err = decoder.Decode(&p.AsApplyExtrinsic)
-	} else if b == 1 {
+	case 1:
 		p.IsFinalization = true
-	} else if b == 2 {
+	case 2:
 		p.IsInitialization = true
 	}
 
@@ -342,12 +343,14 @@ func (p *Phase) Decode(decoder scale.Decoder) error {
 
 func (p Phase) Encode(encoder scale.Encoder) error {
 	var err1, err2 error
-	if p.IsApplyExtrinsic {
+
+	switch {
+	case p.IsApplyExtrinsic:
 		err1 = encoder.PushByte(0)
 		err2 = encoder.Encode(p.AsApplyExtrinsic)
-	} else if p.IsFinalization {
+	case p.IsFinalization:
 		err1 = encoder.PushByte(1)
-	} else if p.IsInitialization {
+	case p.IsInitialization:
 		err1 = encoder.PushByte(2)
 	}
 

--- a/types/event_record_test.go
+++ b/types/event_record_test.go
@@ -292,3 +292,9 @@ func TestDispatchError(t *testing.T) {
 	assertRoundtrip(t, DispatchError{HasModule: true, Module: 0xf1, Error: 0xa2})
 	assertRoundtrip(t, DispatchError{HasModule: false, Error: 0xa2})
 }
+
+func TestPhase(t *testing.T) {
+	assertRoundtrip(t, Phase{IsApplyExtrinsic: true, AsApplyExtrinsic: 43})
+	assertRoundtrip(t, Phase{IsFinalization: true})
+	assertRoundtrip(t, Phase{IsInitialization: true})
+}


### PR DESCRIPTION
This was added sometime between the alpha and RC versions of Substrate.

See https://substrate.dev/rustdocs/v2.0.0-rc6/frame_system/enum.Phase.html