### PR TITLE
refcount to u8 from u32

### DIFF
--- a/signature/signature.go
+++ b/signature/signature.go
@@ -54,7 +54,7 @@ func KeyringPairFromSecret(seedOrPhrase, network string) (KeyringPair, error) {
 	if network != "" {
 		args = []string{"--network", network}
 	}
-	args = append([]string{"inspect", "--output-type", "Json", seedOrPhrase}, args...)
+	args = append([]string{"inspect-key", "--output-type", "Json", "--uri", seedOrPhrase}, args...)
 
 	// use "subkey" command for creation of public key and address
 	cmd := exec.Command(subkeyCmd, args...)

--- a/signature/signature.go
+++ b/signature/signature.go
@@ -54,7 +54,7 @@ func KeyringPairFromSecret(seedOrPhrase, network string) (KeyringPair, error) {
 	if network != "" {
 		args = []string{"--network", network}
 	}
-	args = append([]string{"inspect-key", "--output-type", "Json", "--uri", seedOrPhrase}, args...)
+	args = append([]string{"inspect", "--output-type", "Json", seedOrPhrase}, args...)
 
 	// use "subkey" command for creation of public key and address
 	cmd := exec.Command(subkeyCmd, args...)

--- a/types/account_data.go
+++ b/types/account_data.go
@@ -19,7 +19,7 @@ package types
 // AccountInfo contains information of an account
 type AccountInfo struct {
 	Nonce    U32
-	Refcount U8
+	Refcount U32
 	Data     struct {
 		Free       U128
 		Reserved   U128

--- a/types/account_data.go
+++ b/types/account_data.go
@@ -19,7 +19,7 @@ package types
 // AccountInfo contains information of an account
 type AccountInfo struct {
 	Nonce    U32
-	Refcount U32
+	Refcount U8
 	Data     struct {
 		Free       U128
 		Reserved   U128


### PR DESCRIPTION
- Refcount is U8. 
Fetching `AccountInfo` will fail since refCount u32 swallows 3 bytes extra