### PR TITLE
update imports to v2

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"log"
 
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
+	gethrpc "github.com/centrifuge/go-substrate-rpc-client/v2/gethrpc"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 type Client interface {

--- a/doc.go
+++ b/doc.go
@@ -36,15 +36,15 @@ In order to sign extrinsics, you need to have [subkey](https://github.com/parity
 
 Types
 
-The package [types](https://godoc.org/github.com/centrifuge/go-substrate-rpc-client/types/) exports a number
+The package [types](https://godoc.org/github.com/centrifuge/go-substrate-rpc-client/v2/types/) exports a number
 of useful basic types including functions for encoding and decoding them.
 
 To use your own custom types, you can simply create structs and arrays composing those basic types. Here are some
 examples using composition of a mix of these basic and builtin Go types:
 
-1. Vectors, lists, series, sets, arrays, slices: https://godoc.org/github.com/centrifuge/go-substrate-rpc-client/types/#example_Vec_simple
+1. Vectors, lists, series, sets, arrays, slices: https://godoc.org/github.com/centrifuge/go-substrate-rpc-client/v2/types/#example_Vec_simple
 
-2. Structs: https://godoc.org/github.com/centrifuge/go-substrate-rpc-client/types/#example_Struct_simple
+2. Structs: https://godoc.org/github.com/centrifuge/go-substrate-rpc-client/v2/types/#example_Struct_simple
 
 There are some caveats though that you should be aware of:
 
@@ -56,6 +56,6 @@ methods that implement the Encodeable/Decodeable interfaces. Examples for that a
 types, you can find reference implementations of those here: types/enum_test.go , types/tuple_test.go and
 types/vec_any_test.go
 
-For more information about the types sub-package, see https://godoc.org/github.com/centrifuge/go-substrate-rpc-client/types
+For more information about the types sub-package, see https://godoc.org/github.com/centrifuge/go-substrate-rpc-client/v2/types
 */
 package gsrpc

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/centrifuge/go-substrate-rpc-client
+module github.com/centrifuge/go-substrate-rpc-client/v2
 
 go 1.15
 

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,6 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
-golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d h1:2+ZP7EfsZV7Vvmx3TIqSlSzATMkTAKqM14YGFPoSKjI=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/main.go
+++ b/main.go
@@ -17,8 +17,8 @@
 package gsrpc
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/rpc"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/rpc"
 )
 
 type SubstrateAPI struct {

--- a/main_test.go
+++ b/main_test.go
@@ -21,10 +21,10 @@ import (
 	"math/big"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	gsrpc "github.com/centrifuge/go-substrate-rpc-client/v2"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/signature"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func Example_simpleConnect() {

--- a/rpc/author/author.go
+++ b/rpc/author/author.go
@@ -16,7 +16,7 @@
 
 package author
 
-import "github.com/centrifuge/go-substrate-rpc-client/client"
+import "github.com/centrifuge/go-substrate-rpc-client/v2/client"
 
 // Author exposes methods for authoring of network items
 type Author struct {

--- a/rpc/author/author_test.go
+++ b/rpc/author/author_test.go
@@ -20,8 +20,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/rpcmocksrv"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/rpcmocksrv"
 )
 
 var author *Author

--- a/rpc/author/pending_extrinsics.go
+++ b/rpc/author/pending_extrinsics.go
@@ -17,7 +17,7 @@
 package author
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // PendingExtrinsics returns all pending extrinsics, potentially grouped by sender

--- a/rpc/author/pending_extrinsics_test.go
+++ b/rpc/author/pending_extrinsics_test.go
@@ -19,7 +19,7 @@ package author
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/author/submit_and_watch_extrinsic.go
+++ b/rpc/author/submit_and_watch_extrinsic.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
+	gethrpc "github.com/centrifuge/go-substrate-rpc-client/v2/gethrpc"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // ExtrinsicStatusSubscription is a subscription established through one of the Client's subscribe methods.

--- a/rpc/author/submit_extrinsic.go
+++ b/rpc/author/submit_extrinsic.go
@@ -16,7 +16,7 @@
 
 package author
 
-import "github.com/centrifuge/go-substrate-rpc-client/types"
+import "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 
 // SubmitExtrinsic will submit a fully formatted extrinsic for block inclusion
 func (a *Author) SubmitExtrinsic(xt types.Extrinsic) (types.Hash, error) {

--- a/rpc/author/submit_extrinsic_test.go
+++ b/rpc/author/submit_extrinsic_test.go
@@ -19,7 +19,7 @@ package author
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/chain/chain.go
+++ b/rpc/chain/chain.go
@@ -17,7 +17,7 @@
 package chain
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
 )
 
 // Chain exposes methods for retrieval of chain data

--- a/rpc/chain/chain_test.go
+++ b/rpc/chain/chain_test.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/rpcmocksrv"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/rpcmocksrv"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 var chain *Chain

--- a/rpc/chain/get_block.go
+++ b/rpc/chain/get_block.go
@@ -17,8 +17,8 @@
 package chain
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetBlock returns the header and body of the relay chain block with the given hash

--- a/rpc/chain/get_block_hash.go
+++ b/rpc/chain/get_block_hash.go
@@ -17,7 +17,7 @@
 package chain
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetBlockHash returns the block hash for a specific block height

--- a/rpc/chain/get_block_hash_test.go
+++ b/rpc/chain/get_block_hash_test.go
@@ -19,7 +19,7 @@ package chain
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/chain/get_finalized_head.go
+++ b/rpc/chain/get_finalized_head.go
@@ -17,7 +17,7 @@
 package chain
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetFinalizedHead returns the hash of the last finalized block in the canon chain

--- a/rpc/chain/get_finalized_head_test.go
+++ b/rpc/chain/get_finalized_head_test.go
@@ -19,7 +19,7 @@ package chain
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/chain/get_header.go
+++ b/rpc/chain/get_header.go
@@ -17,8 +17,8 @@
 package chain
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetHeader retrieves the header for the specific block

--- a/rpc/chain/subscribe_finalized_heads.go
+++ b/rpc/chain/subscribe_finalized_heads.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
+	gethrpc "github.com/centrifuge/go-substrate-rpc-client/v2/gethrpc"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // FinalizedHeadsSubscription is a subscription established through one of the Client's subscribe methods.

--- a/rpc/chain/subscribe_new_heads.go
+++ b/rpc/chain/subscribe_new_heads.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
+	gethrpc "github.com/centrifuge/go-substrate-rpc-client/v2/gethrpc"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // NewHeadsSubscription is a subscription established through one of the Client's subscribe methods.

--- a/rpc/main.go
+++ b/rpc/main.go
@@ -17,12 +17,12 @@
 package rpc
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/rpc/author"
-	"github.com/centrifuge/go-substrate-rpc-client/rpc/chain"
-	"github.com/centrifuge/go-substrate-rpc-client/rpc/state"
-	"github.com/centrifuge/go-substrate-rpc-client/rpc/system"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/rpc/author"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/rpc/chain"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/rpc/state"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/rpc/system"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 type RPC struct {

--- a/rpc/state/get_child_keys.go
+++ b/rpc/state/get_child_keys.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetChildKeys retreives the keys with the given prefix of a specific child storage

--- a/rpc/state/get_child_keys_test.go
+++ b/rpc/state/get_child_keys_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/get_child_storage.go
+++ b/rpc/state/get_child_storage.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetChildStorage retreives the child storage for a key and decodes them into the provided interface. Ok is true if the

--- a/rpc/state/get_child_storage_hash.go
+++ b/rpc/state/get_child_storage_hash.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetChildStorageHash retreives the child storage hash for the given key

--- a/rpc/state/get_child_storage_hash_test.go
+++ b/rpc/state/get_child_storage_hash_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/get_child_storage_size.go
+++ b/rpc/state/get_child_storage_size.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetChildStorageSize retreives the child storage size for the given key

--- a/rpc/state/get_child_storage_test.go
+++ b/rpc/state/get_child_storage_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/get_keys.go
+++ b/rpc/state/get_keys.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetKeys retreives the keys with the given prefix

--- a/rpc/state/get_keys_test.go
+++ b/rpc/state/get_keys_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/get_metadata.go
+++ b/rpc/state/get_metadata.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetMetadata returns the metadata at the given block

--- a/rpc/state/get_runtime_version.go
+++ b/rpc/state/get_runtime_version.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetRuntimeVersion returns the runtime version at the given block

--- a/rpc/state/get_storage.go
+++ b/rpc/state/get_storage.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetStorage retreives the stored data and decodes them into the provided interface. Ok is true if the value is not

--- a/rpc/state/get_storage_hash.go
+++ b/rpc/state/get_storage_hash.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetStorageHash retreives the storage hash for the given key

--- a/rpc/state/get_storage_hash_test.go
+++ b/rpc/state/get_storage_hash_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/get_storage_size.go
+++ b/rpc/state/get_storage_size.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // GetStorageSize retreives the storage size for the given key

--- a/rpc/state/get_storage_size_test.go
+++ b/rpc/state/get_storage_size_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/get_storage_test.go
+++ b/rpc/state/get_storage_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/query_storage.go
+++ b/rpc/state/query_storage.go
@@ -17,8 +17,8 @@
 package state
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // QueryStorage queries historical storage entries (by key) starting from a start block until an end block

--- a/rpc/state/query_storage_test.go
+++ b/rpc/state/query_storage_test.go
@@ -19,7 +19,7 @@ package state
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rpc/state/state.go
+++ b/rpc/state/state.go
@@ -16,7 +16,7 @@
 
 package state
 
-import "github.com/centrifuge/go-substrate-rpc-client/client"
+import "github.com/centrifuge/go-substrate-rpc-client/v2/client"
 
 // State exposes methods for querying state
 type State struct {

--- a/rpc/state/state_test.go
+++ b/rpc/state/state_test.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/rpcmocksrv"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/rpcmocksrv"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 var state *State

--- a/rpc/state/subscribe_runtime_version.go
+++ b/rpc/state/subscribe_runtime_version.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
+	gethrpc "github.com/centrifuge/go-substrate-rpc-client/v2/gethrpc"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // RuntimeVersionSubscription is a subscription established through one of the Client's subscribe methods.

--- a/rpc/state/subscribe_storage.go
+++ b/rpc/state/subscribe_storage.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
+	gethrpc "github.com/centrifuge/go-substrate-rpc-client/v2/gethrpc"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // StorageSubscription is a subscription established through one of the Client's subscribe methods.

--- a/rpc/system/chain.go
+++ b/rpc/system/chain.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // Chain retrieves the chain

--- a/rpc/system/health.go
+++ b/rpc/system/health.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // Health retrieves the health status of the connected node

--- a/rpc/system/name.go
+++ b/rpc/system/name.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // Name retrieves the node name

--- a/rpc/system/network_state.go
+++ b/rpc/system/network_state.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // NetworkState retrieves the current state of the network

--- a/rpc/system/peers.go
+++ b/rpc/system/peers.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // Peers retrieves the currently connected peers

--- a/rpc/system/properties.go
+++ b/rpc/system/properties.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // Properties retrieves a custom set of properties as a JSON object, defined in the chain spec

--- a/rpc/system/system.go
+++ b/rpc/system/system.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
 )
 
 // System exposes methods for retrieval of system data

--- a/rpc/system/system_test.go
+++ b/rpc/system/system_test.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/client"
-	"github.com/centrifuge/go-substrate-rpc-client/rpcmocksrv"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/rpcmocksrv"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 var system *System

--- a/rpc/system/version.go
+++ b/rpc/system/version.go
@@ -17,7 +17,7 @@
 package system
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // Version retrieves the version of the node

--- a/rpcmocksrv/server.go
+++ b/rpcmocksrv/server.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"time"
 
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
+	gethrpc "github.com/centrifuge/go-substrate-rpc-client/v2/gethrpc"
 )
 
 type Server struct {

--- a/rpcmocksrv/server_test.go
+++ b/rpcmocksrv/server_test.go
@@ -19,7 +19,7 @@ package rpcmocksrv
 import (
 	"testing"
 
-	gethrpc "github.com/centrifuge/go-substrate-rpc-client/gethrpc"
+	gethrpc "github.com/centrifuge/go-substrate-rpc-client/v2/gethrpc"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/signature/signature_test.go
+++ b/signature/signature_test.go
@@ -20,8 +20,8 @@ import (
 	"crypto/rand"
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/signature"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/signature"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teste2e/author_submit_and_watch_extrinsic_test.go
+++ b/teste2e/author_submit_and_watch_extrinsic_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	gsrpc "github.com/centrifuge/go-substrate-rpc-client/v2"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/signature"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teste2e/author_submit_extrinsic_test.go
+++ b/teste2e/author_submit_extrinsic_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	gsrpc "github.com/centrifuge/go-substrate-rpc-client/v2"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/signature"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestChain_Events(t *testing.T) {

--- a/teste2e/chain_subscribe_finalized_heads_test.go
+++ b/teste2e/chain_subscribe_finalized_heads_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
+	gsrpc "github.com/centrifuge/go-substrate-rpc-client/v2"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teste2e/chain_subscribe_new_heads_test.go
+++ b/teste2e/chain_subscribe_new_heads_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
+	gsrpc "github.com/centrifuge/go-substrate-rpc-client/v2"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teste2e/main_test.go
+++ b/teste2e/main_test.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"testing"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	gsrpc "github.com/centrifuge/go-substrate-rpc-client/v2"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teste2e/state_subscribe_runtime_version_test.go
+++ b/teste2e/state_subscribe_runtime_version_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
+	gsrpc "github.com/centrifuge/go-substrate-rpc-client/v2"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/teste2e/state_subscribe_storage_test.go
+++ b/teste2e/state_subscribe_storage_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client"
-	"github.com/centrifuge/go-substrate-rpc-client/config"
-	"github.com/centrifuge/go-substrate-rpc-client/types"
+	gsrpc "github.com/centrifuge/go-substrate-rpc-client/v2"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/config"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/account_id_test.go
+++ b/types/account_id_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestAccountID_EncodeDecode(t *testing.T) {

--- a/types/account_index_test.go
+++ b/types/account_index_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestAccountIndex_EncodeDecode(t *testing.T) {

--- a/types/account_info_test.go
+++ b/types/account_info_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestAccountInfoV4_EncodeDecode(t *testing.T) {

--- a/types/address.go
+++ b/types/address.go
@@ -19,7 +19,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // Address is a wrapper around an AccountId or an AccountIndex. It is encoded with a prefix in case of an AccountID.

--- a/types/address_test.go
+++ b/types/address_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/centrifuge/go-substrate-rpc-client/hash"
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/hash"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/balance_status.go
+++ b/types/balance_status.go
@@ -3,7 +3,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 type BalanceStatus byte

--- a/types/balance_status_test.go
+++ b/types/balance_status_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/bool_test.go
+++ b/types/bool_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestBool_EncodeDecode(t *testing.T) {

--- a/types/bytes.go
+++ b/types/bytes.go
@@ -19,7 +19,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // Bytes represents byte slices. Bytes has a variable length, it is encoded with a scale prefix

--- a/types/bytes_test.go
+++ b/types/bytes_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestBytes_EncodeDecode(t *testing.T) {

--- a/types/chain_properties.go
+++ b/types/chain_properties.go
@@ -17,7 +17,7 @@
 package types
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // ChainProperties contains the SS58 format, the token decimals and the token symbol

--- a/types/chain_properties_test.go
+++ b/types/chain_properties_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 var testChainProperties1 = ChainProperties{}

--- a/types/codec.go
+++ b/types/codec.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/types/data.go
+++ b/types/data.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // Data is a raw data structure, containing raw bytes that are not decoded/encoded (without any length encoding).

--- a/types/data_test.go
+++ b/types/data_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/digest_item.go
+++ b/types/digest_item.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 
 // DigestItem specifies the item in the logs of a digest
 type DigestItem struct {

--- a/types/digest_item_test.go
+++ b/types/digest_item_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 var testDigestItem1 = DigestItem{IsOther: true, AsOther: NewBytes([]byte{0xab})}

--- a/types/digest_of_test.go
+++ b/types/digest_of_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestDigestOf_EncodeDecode(t *testing.T) {

--- a/types/digest_test.go
+++ b/types/digest_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestDigest_EncodeDecode(t *testing.T) {

--- a/types/election_compute.go
+++ b/types/election_compute.go
@@ -3,7 +3,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 type ElectionCompute byte

--- a/types/election_compute_test.go
+++ b/types/election_compute_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/event_record.go
+++ b/types/event_record.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 	"github.com/ethereum/go-ethereum/log"
 )
 

--- a/types/event_record_test.go
+++ b/types/event_record_test.go
@@ -21,7 +21,7 @@ import (
 	"math/big"
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/events.go
+++ b/types/events.go
@@ -19,7 +19,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // EventBalancesEndowed is emitted when an account is created with some free balance

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/example_enum_test.go
+++ b/types/example_enum_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // PhaseEnum is an enum example. Since Go has no enums, it is implemented as a struct with flags for each

--- a/types/example_struct_test.go
+++ b/types/example_struct_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"fmt"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func ExampleExampleStruct() {

--- a/types/example_tuple_test.go
+++ b/types/example_tuple_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"fmt"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 
 	"golang.org/x/crypto/blake2b"
 )

--- a/types/example_vec_any_test.go
+++ b/types/example_vec_any_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // MyVal is a custom type that is used to hold arbitrarily encoded data. In this example, we encode uint8s with a 0x00

--- a/types/example_vec_test.go
+++ b/types/example_vec_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func ExampleExampleVec_simple() {

--- a/types/extrinsic.go
+++ b/types/extrinsic.go
@@ -24,8 +24,8 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/signature"
 )
 
 const (

--- a/types/extrinsic_era.go
+++ b/types/extrinsic_era.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 
 // ExtrinsicEra indicates either a mortal or immortal extrinsic
 type ExtrinsicEra struct {

--- a/types/extrinsic_era_test.go
+++ b/types/extrinsic_era_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/extrinsic_payload.go
+++ b/types/extrinsic_payload.go
@@ -19,8 +19,8 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/signature"
 )
 
 // ExtrinsicPayloadV3 is a signing payload for an Extrinsic. For the final encoding, it is variable length based on

--- a/types/extrinsic_payload_test.go
+++ b/types/extrinsic_payload_test.go
@@ -19,8 +19,8 @@ package types_test
 import (
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/signature"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/extrinsic_signature_test.go
+++ b/types/extrinsic_signature_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/extrinsic_status.go
+++ b/types/extrinsic_status.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // ExtrinsicStatus is an enum containing the result of an extrinsic submission

--- a/types/extrinsic_status_test.go
+++ b/types/extrinsic_status_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/extrinsic_test.go
+++ b/types/extrinsic_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/signature"
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/signature"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/hash_test.go
+++ b/types/hash_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 var hash20 = []byte{

--- a/types/header.go
+++ b/types/header.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 type Header struct {

--- a/types/header_test.go
+++ b/types/header_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 var exampleHeader = Header{

--- a/types/health_test.go
+++ b/types/health_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestHealth_EncodeDecode(t *testing.T) {

--- a/types/int.go
+++ b/types/int.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // I8 is a signed 8-bit integer

--- a/types/int_test.go
+++ b/types/int_test.go
@@ -20,7 +20,7 @@ import (
 	"math/big"
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/metadata.go
+++ b/types/metadata.go
@@ -19,7 +19,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 const MagicNumber uint32 = 0x6174656d

--- a/types/metadataV10.go
+++ b/types/metadataV10.go
@@ -22,9 +22,9 @@ import (
 	"hash"
 	"strings"
 
-	ghash "github.com/centrifuge/go-substrate-rpc-client/hash"
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	"github.com/centrifuge/go-substrate-rpc-client/xxhash"
+	ghash "github.com/centrifuge/go-substrate-rpc-client/v2/hash"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/xxhash"
 )
 
 // Modelled after packages/types/src/Metadata/v10/Metadata.ts

--- a/types/metadataV10_test.go
+++ b/types/metadataV10_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/metadataV11.go
+++ b/types/metadataV11.go
@@ -1,6 +1,6 @@
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 
 // Modelled after packages/types/src/Metadata/v10/toV11.ts
 type MetadataV11 struct {

--- a/types/metadataV11_test.go
+++ b/types/metadataV11_test.go
@@ -3,7 +3,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/metadataV12.go
+++ b/types/metadataV12.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // Modelled after packages/types/src/Metadata/v11/toV12.ts

--- a/types/metadataV12_test.go
+++ b/types/metadataV12_test.go
@@ -3,7 +3,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/metadataV4.go
+++ b/types/metadataV4.go
@@ -22,8 +22,8 @@ import (
 	"hash"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	"github.com/centrifuge/go-substrate-rpc-client/xxhash"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/xxhash"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/types/metadataV4_test.go
+++ b/types/metadataV4_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/types/metadataV7.go
+++ b/types/metadataV7.go
@@ -21,8 +21,8 @@ import (
 	"hash"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	"github.com/centrifuge/go-substrate-rpc-client/xxhash"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/xxhash"
 )
 
 // Modelled after packages/types/src/Metadata/v7/Metadata.ts

--- a/types/metadataV7_test.go
+++ b/types/metadataV7_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 var exampleMetadataV7 = Metadata{

--- a/types/metadataV8.go
+++ b/types/metadataV8.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // Modelled after packages/types/src/Metadata/v8/Metadata.ts

--- a/types/metadataV8_test.go
+++ b/types/metadataV8_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/metadataV9.go
+++ b/types/metadataV9.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // Modelled after packages/types/src/Metadata/v9/Metadata.ts

--- a/types/metadataV9_test.go
+++ b/types/metadataV9_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/moment.go
+++ b/types/moment.go
@@ -21,7 +21,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 const (

--- a/types/moment_test.go
+++ b/types/moment_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestMoment_EncodeDecode(t *testing.T) {

--- a/types/multi_signature.go
+++ b/types/multi_signature.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 
 // MultiSignature
 type MultiSignature struct {

--- a/types/multi_signature_test.go
+++ b/types/multi_signature_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 var testMultiSig1 = MultiSignature{IsEd25519: true, AsEd25519: NewSignature(hash64)}

--- a/types/network_state_test.go
+++ b/types/network_state_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestNetworkState_EncodeDecode(t *testing.T) {

--- a/types/null.go
+++ b/types/null.go
@@ -17,7 +17,7 @@
 package types
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // Null is a type that does not contain anything (apart from null)

--- a/types/null_test.go
+++ b/types/null_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestNull_EncodeDecode(t *testing.T) {

--- a/types/option_bool.go
+++ b/types/option_bool.go
@@ -19,7 +19,7 @@ package types
 import (
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // OptionBool is a structure that can store a Bool or a missing value

--- a/types/option_bool_test.go
+++ b/types/option_bool_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestOptionBool_EncodeDecode(t *testing.T) {

--- a/types/option_bytes.go
+++ b/types/option_bytes.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 
 // OptionBytes is a structure that can store a Bytes or a missing value
 type OptionBytes struct {

--- a/types/option_bytes_test.go
+++ b/types/option_bytes_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestOptionBytes8_EncodeDecode(t *testing.T) {

--- a/types/option_hash.go
+++ b/types/option_hash.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 
 // OptionH160 is a structure that can store a H160 or a missing value
 type OptionH160 struct {

--- a/types/option_hash_test.go
+++ b/types/option_hash_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestOptionH160_EncodeDecode(t *testing.T) {

--- a/types/option_int.go
+++ b/types/option_int.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 
 // OptionI8 is a structure that can store a I8 or a missing value
 type OptionI8 struct {

--- a/types/option_int_test.go
+++ b/types/option_int_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestOptionI8_EncodeDecode(t *testing.T) {

--- a/types/option_uint.go
+++ b/types/option_uint.go
@@ -16,7 +16,7 @@
 
 package types
 
-import "github.com/centrifuge/go-substrate-rpc-client/scale"
+import "github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 
 // OptionU8 is a structure that can store a U8 or a missing value
 type OptionU8 struct {

--- a/types/option_uint_test.go
+++ b/types/option_uint_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestOptionU8_EncodeDecode(t *testing.T) {

--- a/types/origin.go
+++ b/types/origin.go
@@ -17,7 +17,7 @@
 package types
 
 import (
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // Origin is an internal-only value that will be ignored when encoding/decoding

--- a/types/origin_test.go
+++ b/types/origin_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 // newOrigin creates a new Origin type. This function is not exported by purpose – Origin should be ignored and not be

--- a/types/peer_info_test.go
+++ b/types/peer_info_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 var testPeerInfo = PeerInfo{

--- a/types/runtime_version.go
+++ b/types/runtime_version.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 type RuntimeVersion struct {

--- a/types/runtime_version_test.go
+++ b/types/runtime_version_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/signature_test.go
+++ b/types/signature_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestSignature_EncodeDecode(t *testing.T) {

--- a/types/signed_block_test.go
+++ b/types/signed_block_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/storage_change_set_test.go
+++ b/types/storage_change_set_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/storage_data_raw.go
+++ b/types/storage_data_raw.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // StorageDataRaw contains raw bytes that are not decoded/encoded.

--- a/types/storage_data_raw_test.go
+++ b/types/storage_data_raw_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/storage_key.go
+++ b/types/storage_key.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	"github.com/centrifuge/go-substrate-rpc-client/xxhash"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/xxhash"
 )
 
 // StorageKey represents typically hashed storage keys of the system.

--- a/types/storage_key_test.go
+++ b/types/storage_key_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/test_utils_test.go
+++ b/types/test_utils_test.go
@@ -22,8 +22,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/text_test.go
+++ b/types/text_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestString_EncodeDecode(t *testing.T) {

--- a/types/type_test.go
+++ b/types/type_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestType_EncodeDecode(t *testing.T) {

--- a/types/ucompact.go
+++ b/types/ucompact.go
@@ -19,7 +19,7 @@ package types
 import (
 	"math/big"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 type UCompact big.Int

--- a/types/uint.go
+++ b/types/uint.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
 )
 
 // U8 is an unsigned 8-bit integer

--- a/types/uint_test.go
+++ b/types/uint_test.go
@@ -21,8 +21,8 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/scale"
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v2/scale"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types/usize_test.go
+++ b/types/usize_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestUSize_EncodeDecode(t *testing.T) {

--- a/types/weight_multiplier_test.go
+++ b/types/weight_multiplier_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestWeightMultiplier_EncodeDecode(t *testing.T) {

--- a/types/weight_test.go
+++ b/types/weight_test.go
@@ -19,7 +19,7 @@ package types_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/types"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/types"
 )
 
 func TestWeight_EncodeDecode(t *testing.T) {

--- a/xxhash/xxhash_test.go
+++ b/xxhash/xxhash_test.go
@@ -19,7 +19,7 @@ package xxhash_test
 import (
 	"testing"
 
-	. "github.com/centrifuge/go-substrate-rpc-client/xxhash"
+	. "github.com/centrifuge/go-substrate-rpc-client/v2/xxhash"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
V2+ with modules require a bit of change than v0 or v1

With the introduction of v2, the module import should be prefixed with the `/v2` else modules end up pointing to old versions.

Users fetching this library as `go get -u github.com/.../go-subsstrate-rpc-client@v2.0.1` will fail since the v2+ is treated differently on go modules and there by causing an error while `go get ...`


**Note**: Once this is merged, we would need to update the tag with latest commit for this to work correctly