### PR TITLE
Offchain RPC methods should not SCALE-encode keys & values

### DIFF
--- a/rpc/offchain/get_local_storage.go
+++ b/rpc/offchain/get_local_storage.go
@@ -20,12 +20,7 @@ const (
 func (c *Offchain) LocalStorageGet(kind StorageKind, key []byte) (*types.StorageDataRaw, error) {
 	var res string
 
-	kb, err := types.EncodeToHexString(key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode key: %w", err)
-	}
-
-	err = c.client.Call(&res, "offchain_localStorageGet", kind, kb)
+	err := c.client.Call(&res, "offchain_localStorageGet", kind, fmt.Sprintf("%#x", key))
 	if err != nil {
 		return nil, err
 	}
@@ -47,17 +42,7 @@ func (c *Offchain) LocalStorageGet(kind StorageKind, key []byte) (*types.Storage
 func (c *Offchain) LocalStorageSet(kind StorageKind, key []byte, value []byte) error {
 	var res string
 
-	kb, err := types.EncodeToHexString(key)
-	if err != nil {
-		return fmt.Errorf("failed to encode key: %w", err)
-	}
-
-	vb, err := types.EncodeToHexString(value)
-	if err != nil {
-		return fmt.Errorf("failed to encode value: %w", err)
-	}
-
-	err = c.client.Call(&res, "offchain_localStorageSet", kind, kb, vb)
+	err := c.client.Call(&res, "offchain_localStorageSet", kind, fmt.Sprintf("%#x", key), fmt.Sprintf("%#x", value))
 	if err != nil {
 		return err
 	}

--- a/rpc/offchain/get_local_storage_test.go
+++ b/rpc/offchain/get_local_storage_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"testing"
 
-	"github.com/centrifuge/go-substrate-rpc-client/v3/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,18 +13,17 @@ func TestOffchain_LocalStorageGetSet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 20, n)
 
+	value := []byte{0, 1, 2}
+
 	data, err := offchain.LocalStorageGet(Persistent, key)
 	assert.NoError(t, err)
 	assert.Empty(t, data)
 
-	err = offchain.LocalStorageSet(Persistent, key, key)
+	err = offchain.LocalStorageSet(Persistent, key, value)
 	assert.NoError(t, err)
 
 	data, err = offchain.LocalStorageGet(Persistent, key)
 	assert.NoError(t, err)
 
-	got := make([]byte, 0, 20)
-	err = types.DecodeFromHexString(data.Hex(), &got)
-	assert.NoError(t, err)
-	assert.Equal(t, key, got)
+	assert.Equal(t, value, []byte(*data))
 }


### PR DESCRIPTION
The Offchain DB should be treated as a generic key-value store, taking raw bytes for keys & values. The current implementation prevents us from reading values for arbitrary keys.