### PR TITLE
ported mortal era encoding from its rust implementation

### DIFF
--- a/types/extrinsic_era_test.go
+++ b/types/extrinsic_era_test.go
@@ -45,3 +45,71 @@ func TestExtrinsicEra_EncodeDecode(t *testing.T) {
 	assert.NoError(t, err)
 	assertRoundtrip(t, e)
 }
+
+func TestExtrinsicEra_MortalEraEncoding(t *testing.T) {
+	testCases := []struct {
+		Current        uint64
+		ValidityPeriod uint64
+		Era            MortalEra
+	}{
+		{
+			Current:        2251516,
+			ValidityPeriod: 64,
+			Era:            MortalEra{First: 0xc5, Second: 0x03},
+		},
+	}
+
+	for _, testCase := range testCases {
+		period, phase := Mortal(testCase.ValidityPeriod, testCase.Current)
+
+		era := NewMortalEra(period, phase)
+		assert.Equal(t, testCase.Era.First, era.First)
+		assert.Equal(t, testCase.Era.Second, era.Second)
+	}
+}
+
+func TestMortal(t *testing.T) {
+	period, phase := Mortal(200, 1400)
+	assert.Equal(t, uint64(120), phase)
+	assert.Equal(t, uint64(256), period)
+}
+
+func TestNewMortalEra(t *testing.T) {
+	testCases := []struct {
+		Period uint64
+		Phase  uint64
+		Era    MortalEra
+	}{
+		{
+			Period: 128,
+			Phase:  125,
+			Era:    MortalEra{First: 0xd6, Second: 0x07},
+		},
+		{
+			Period: 4096,
+			Phase:  3641,
+			Era:    MortalEra{First: 0x9b, Second: 0xe3},
+		},
+		{
+			Period: 64,
+			Phase:  38,
+			Era:    MortalEra{First: 0x65, Second: 0x02},
+		},
+		{
+			Period: 64,
+			Phase:  40,
+			Era:    MortalEra{First: 0x85, Second: 0x02},
+		},
+		{
+			Period: 32768,
+			Phase:  20000,
+			Era:    MortalEra{First: 78, Second: 156},
+		},
+	}
+
+	for _, testCase := range testCases {
+		era := NewMortalEra(testCase.Period, testCase.Phase)
+		assert.Equal(t, testCase.Era.First, era.First)
+		assert.Equal(t, testCase.Era.Second, era.Second)
+	}
+}


### PR DESCRIPTION
I ported the mortal era encoding from its rust implementation, which can be found there
https://github.com/paritytech/substrate/blob/c2ec5bc8f12bb5a084b976f2dc1280796e9c1b23/primitives/runtime/src/generic/era.rs#L66

Mortal era encoding can be tricky. What a good thing that we now have a golang implementation.
