### PR TITLE
Add support for state_queryStorageAt RPC

### DIFF
--- a/rpc/state/query_storage_at.go
+++ b/rpc/state/query_storage_at.go
@@ -1,0 +1,47 @@
+// Go Substrate RPC Client (GSRPC) provides APIs and types around Polkadot and any Substrate-based chain RPC calls
+//
+// Copyright 2022 Snowfork
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"github.com/snowfork/go-substrate-rpc-client/v4/client"
+	"github.com/snowfork/go-substrate-rpc-client/v4/types"
+)
+
+// QueryStorageAt ...
+func (s *State) QueryStorageAt(keys []types.StorageKey, block types.Hash) ([]types.StorageChangeSet, error) {
+	return s.queryStorageAt(keys, &block)
+}
+
+// QueryStorageAtLatest ...
+func (s *State) QueryStorageAtLatest(keys []types.StorageKey) ([]types.StorageChangeSet, error) {
+	return s.queryStorageAt(keys, nil)
+}
+
+func (s *State) queryStorageAt(keys []types.StorageKey, block *types.Hash) ([]types.StorageChangeSet, error) {
+	hexKeys := make([]string, len(keys))
+	for i, key := range keys {
+		hexKeys[i] = key.Hex()
+	}
+
+	var res []types.StorageChangeSet
+	err := client.CallWithBlockHash(s.client, &res, "state_queryStorageAt", block, hexKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/rpc/state/query_storage_at.go
+++ b/rpc/state/query_storage_at.go
@@ -17,21 +17,21 @@
 package state
 
 import (
-	"github.com/snowfork/go-substrate-rpc-client/v4/client"
-	"github.com/snowfork/go-substrate-rpc-client/v4/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v4/client"
+	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
 )
 
 // QueryStorageAt ...
-func (s *State) QueryStorageAt(keys []types.StorageKey, block types.Hash) ([]types.StorageChangeSet, error) {
+func (s *state) QueryStorageAt(keys []types.StorageKey, block types.Hash) ([]types.StorageChangeSet, error) {
 	return s.queryStorageAt(keys, &block)
 }
 
 // QueryStorageAtLatest ...
-func (s *State) QueryStorageAtLatest(keys []types.StorageKey) ([]types.StorageChangeSet, error) {
+func (s *state) QueryStorageAtLatest(keys []types.StorageKey) ([]types.StorageChangeSet, error) {
 	return s.queryStorageAt(keys, nil)
 }
 
-func (s *State) queryStorageAt(keys []types.StorageKey, block *types.Hash) ([]types.StorageChangeSet, error) {
+func (s *state) queryStorageAt(keys []types.StorageKey, block *types.Hash) ([]types.StorageChangeSet, error) {
 	hexKeys := make([]string, len(keys))
 	for i, key := range keys {
 		hexKeys[i] = key.Hex()

--- a/rpc/state/query_storage_at_test.go
+++ b/rpc/state/query_storage_at_test.go
@@ -1,0 +1,39 @@
+// Go Substrate RPC Client (GSRPC) provides APIs and types around Polkadot and any Substrate-based chain RPC calls
+//
+// Copyright 2022 Snowfork
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/snowfork/go-substrate-rpc-client/v4/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestState_QueryStorageAtLatest(t *testing.T) {
+	key := types.NewStorageKey(types.MustHexDecodeString(mockSrv.storageKeyHex))
+	data, err := state.QueryStorageAtLatest([]types.StorageKey{key})
+	assert.NoError(t, err)
+	assert.Equal(t, mockSrv.storageChangeSets, data)
+}
+
+func TestState_QueryStorageAt(t *testing.T) {
+	key := types.NewStorageKey(types.MustHexDecodeString(mockSrv.storageKeyHex))
+	hash := types.NewHash(types.MustHexDecodeString("0xdd1816b6f6889f46e23b0d6750bc441af9dad0fda8bae90677c1708d01035fbe"))
+	data, err := state.QueryStorageAt([]types.StorageKey{key}, hash)
+	assert.NoError(t, err)
+	assert.Equal(t, mockSrv.storageChangeSets, data)
+}

--- a/rpc/state/query_storage_at_test.go
+++ b/rpc/state/query_storage_at_test.go
@@ -19,13 +19,13 @@ package state
 import (
 	"testing"
 
-	"github.com/snowfork/go-substrate-rpc-client/v4/types"
+	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestState_QueryStorageAtLatest(t *testing.T) {
 	key := types.NewStorageKey(types.MustHexDecodeString(mockSrv.storageKeyHex))
-	data, err := state.QueryStorageAtLatest([]types.StorageKey{key})
+	data, err := testState.QueryStorageAtLatest([]types.StorageKey{key})
 	assert.NoError(t, err)
 	assert.Equal(t, mockSrv.storageChangeSets, data)
 }
@@ -33,7 +33,7 @@ func TestState_QueryStorageAtLatest(t *testing.T) {
 func TestState_QueryStorageAt(t *testing.T) {
 	key := types.NewStorageKey(types.MustHexDecodeString(mockSrv.storageKeyHex))
 	hash := types.NewHash(types.MustHexDecodeString("0xdd1816b6f6889f46e23b0d6750bc441af9dad0fda8bae90677c1708d01035fbe"))
-	data, err := state.QueryStorageAt([]types.StorageKey{key}, hash)
+	data, err := testState.QueryStorageAt([]types.StorageKey{key}, hash)
 	assert.NoError(t, err)
 	assert.Equal(t, mockSrv.storageChangeSets, data)
 }

--- a/rpc/state/state.go
+++ b/rpc/state/state.go
@@ -53,6 +53,9 @@ type State interface {
 	QueryStorage(keys []types.StorageKey, startBlock types.Hash, block types.Hash) ([]types.StorageChangeSet, error)
 	QueryStorageLatest(keys []types.StorageKey, startBlock types.Hash) ([]types.StorageChangeSet, error)
 
+	QueryStorageAt(keys []types.StorageKey, block types.Hash) ([]types.StorageChangeSet, error)
+	QueryStorageAtLatest(keys []types.StorageKey) ([]types.StorageChangeSet, error)
+
 	GetKeys(prefix types.StorageKey, blockHash types.Hash) ([]types.StorageKey, error)
 	GetKeysLatest(prefix types.StorageKey) ([]types.StorageKey, error)
 

--- a/rpc/state/state_test.go
+++ b/rpc/state/state_test.go
@@ -150,6 +150,17 @@ func (s *MockSrv) QueryStorage(keys []string, startBlock string, block *string) 
 	return mockSrv.storageChangeSets
 }
 
+func (s *MockSrv) QueryStorageAt(keys []string, hash *string) []types.StorageChangeSet {
+	if len(keys) != 1 {
+		panic("keys need to have len of 1 in tests")
+	}
+	if keys[0] != mockSrv.storageKeyHex {
+		panic("key not found")
+	}
+
+	return mockSrv.storageChangeSets
+}
+
 // func (s *MockSrv) SubscribeStorage(args []string) {
 // 	fmt.Println("Hit")
 // }


### PR DESCRIPTION
This is meant to replace the deprecated `state_queryStorage` API, which is marked unsafe and isn't actually callable on most production nodes.

As such `state_queryStorageAt` is the only way to perform a low-level storage query right now.