### PR TITLE
events: Remove polkadot claimed event

### DIFF
--- a/types/event_record.go
+++ b/types/event_record.go
@@ -116,8 +116,6 @@ type EventRecords struct {
 	ChildBounties_Claimed  []EventChildBountiesClaimed  `test-gen-skip:"true"`
 	ChildBounties_Canceled []EventChildBountiesCanceled `test-gen-skip:"true"`
 
-	Claims_Claimed []EventClaimsClaimed `test-gen-blockchain:"polkadot"`
-
 	CollatorSelection_NewInvulnerables     []EventCollatorSelectionNewInvulnerables     `test-gen-blockchain:"altair"`
 	CollatorSelection_NewDesiredCandidates []EventCollatorSelectionNewDesiredCandidates `test-gen-blockchain:"altair"`
 	CollatorSelection_NewCandidacyBond     []EventCollatorSelectionNewCandidacyBond     `test-gen-blockchain:"altair"`

--- a/types/events.go
+++ b/types/events.go
@@ -22,15 +22,6 @@ import (
 	"github.com/centrifuge/go-substrate-rpc-client/v4/scale"
 )
 
-// EventClaimsClaimed is emitted when an account claims some DOTs
-type EventClaimsClaimed struct {
-	Phase           Phase
-	Who             AccountID
-	EthereumAddress H160
-	Amount          U128
-	Topics          []Hash
-}
-
 // EventBalancesEndowed is emitted when an account is created with some free balance
 type EventBalancesEndowed struct {
 	Phase   Phase


### PR DESCRIPTION
Removing the polkadot claimed event since it collides with the one that we have in our Centrifuge chain.