### PR TITLE
peerInfo: Use U32 instead of BlockNumber

### DIFF
--- a/types/peer_info.go
+++ b/types/peer_info.go
@@ -22,5 +22,5 @@ type PeerInfo struct {
 	Roles           Text
 	ProtocolVersion U32
 	BestHash        Hash
-	BestNumber      BlockNumber
+	BestNumber      U32
 }

--- a/types/peer_info_test.go
+++ b/types/peer_info_test.go
@@ -34,17 +34,23 @@ func TestPeerInfo_EncodeDecode(t *testing.T) {
 	assertRoundtrip(t, testPeerInfo)
 	assertRoundTripFuzz[PeerInfo](t, 100)
 	assertDecodeNilData[PeerInfo](t)
-	assertEncodeEmptyObj[PeerInfo](t, 39)
+	assertEncodeEmptyObj[PeerInfo](t, 42)
 }
 
 func TestPeerInfo_Encode(t *testing.T) {
 	assertEncode(t, []encodingAssert{
-		{testPeerInfo, MustHexDecodeString("0x20616263313233343528736f6d6520726f6c65737b000000abcd000000000000000000000000000000000000000000000000000000000000e514")}, //nolint:lll
+		{
+			testPeerInfo,
+			MustHexDecodeString("0x20616263313233343528736f6d6520726f6c65737b000000abcd00000000000000000000000000000000000000000000000000000000000039050000"),
+		},
 	})
 }
 
 func TestPeerInfo_Decode(t *testing.T) {
 	assertDecode(t, []decodingAssert{
-		{MustHexDecodeString("0x20616263313233343528736f6d6520726f6c65737b000000abcd000000000000000000000000000000000000000000000000000000000000e514"), testPeerInfo}, //nolint:lll
+		{
+			MustHexDecodeString("0x20616263313233343528736f6d6520726f6c65737b000000abcd00000000000000000000000000000000000000000000000000000000000039050000"),
+			testPeerInfo,
+		},
 	})
 }


### PR DESCRIPTION
Issue reported on discord by one of our users. Was able to confirm the error caused by the incorrect type.