### PR TITLE
types: Remove FailedToTransactAsset field from XCM Error

### DIFF
--- a/types/event_record.go
+++ b/types/event_record.go
@@ -517,8 +517,6 @@ func (e EventRecordsRaw) DecodeEventRecords(m *Metadata, t interface{}) error { 
 			return fmt.Errorf("unable to find event with EventID %v in metadata for event #%v: %s", id, i, err)
 		}
 
-		// fmt.Printf("event #%v is in module %v with event name %v\n", i, moduleName, eventName)
-
 		log.Debug(fmt.Sprintf("event #%v is in module %v with event name %v", i, moduleName, eventName))
 
 		// check whether name for eventID exists in t

--- a/types/xcm_error.go
+++ b/types/xcm_error.go
@@ -38,7 +38,6 @@ type XCMError struct {
 	IsAssetNotFound bool
 
 	IsFailedToTransactAsset bool
-	FailedToTransactAsset   string
 
 	IsNotWithdrawable bool
 
@@ -103,8 +102,6 @@ func (x *XCMError) Decode(decoder scale.Decoder) error { //nolint: funlen
 		x.IsAssetNotFound = true
 	case 9:
 		x.IsFailedToTransactAsset = true
-
-		return decoder.Decode(&x.FailedToTransactAsset)
 	case 10:
 		x.IsNotWithdrawable = true
 	case 11:
@@ -169,11 +166,7 @@ func (x XCMError) Encode(encoder scale.Encoder) error { //nolint:gocyclo,funlen
 	case x.IsAssetNotFound:
 		return encoder.PushByte(8)
 	case x.IsFailedToTransactAsset:
-		if err := encoder.PushByte(9); err != nil {
-			return err
-		}
-
-		return encoder.Encode(x.FailedToTransactAsset)
+		return encoder.PushByte(9)
 	case x.IsNotWithdrawable:
 		return encoder.PushByte(10)
 	case x.IsLocationCannotHold:

--- a/types/xcm_error_test.go
+++ b/types/xcm_error_test.go
@@ -48,8 +48,6 @@ var (
 				x.IsAssetNotFound = true
 			case 9:
 				x.IsFailedToTransactAsset = true
-
-				c.Fuzz(&x.FailedToTransactAsset)
 			case 10:
 				x.IsNotWithdrawable = true
 			case 11:


### PR DESCRIPTION
The `FailedToTransactAsset` can be safely removed given:
https://github.com/paritytech/polkadot/blob/master/xcm/src/v2/traits.rs#L58