### PR TITLE
Remove extraneous log.Printf call

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -18,7 +18,6 @@ package client
 
 import (
 	"context"
-	"log"
 
 	"github.com/centrifuge/go-substrate-rpc-client/v4/config"
 	gethrpc "github.com/centrifuge/go-substrate-rpc-client/v4/gethrpc"
@@ -59,8 +58,6 @@ func (c client) Close() {
 
 // Connect connects to the provided url
 func Connect(url string) (Client, error) {
-	log.Printf("Connecting to %v...", url)
-
 	ctx, cancel := context.WithTimeout(context.Background(), config.Default().DialTimeout)
 	defer cancel()
 


### PR DESCRIPTION
Looks like this log.Printf call shouldn't be here.