### PR TITLE
Fix type of JunctionV1.AccountID

### DIFF
--- a/types/junction_v1.go
+++ b/types/junction_v1.go
@@ -26,7 +26,7 @@ type JunctionV1 struct {
 
 	IsAccountID32        bool
 	AccountID32NetworkID NetworkID
-	AccountID            []U8
+	AccountID            [32]U8
 
 	IsAccountIndex64        bool
 	AccountIndex64NetworkID NetworkID

--- a/types/junction_v1_test.go
+++ b/types/junction_v1_test.go
@@ -36,7 +36,10 @@ var (
 		AccountID32NetworkID: NetworkID{
 			IsAny: true,
 		},
-		AccountID: []U8{1, 2, 3},
+		AccountID: [32]U8{
+			1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+			17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+		},
 	}
 	testJunctionV1n3 = JunctionV1{
 		IsAccountIndex64: true,


### PR DESCRIPTION
Fixes transaction verification error due to presence of an extra byte 0x80 (scale-encoded number 32) in front of the encoded AccountID in JunctionV1 structure.

https://github.com/paritytech/polkadot/blob/master/xcm/src/v2/junction.rs#L39