### PR TITLE
registry: Add overrides for field decoders

### DIFF
--- a/registry/retriever/event_retriever.go
+++ b/registry/retriever/event_retriever.go
@@ -69,9 +69,10 @@ func NewEventRetriever(
 func NewDefaultEventRetriever(
 	eventProvider regState.EventProvider,
 	stateRPC state.State,
+	fieldOverrides ...registry.FieldOverride,
 ) (EventRetriever, error) {
 	eventParser := parser.NewEventParser()
-	registryFactory := registry.NewFactory()
+	registryFactory := registry.NewFactory(fieldOverrides...)
 
 	eventStorageExecutor := exec.NewRetryableExecutor[*types.StorageDataRaw](exec.WithRetryTimeout(1 * time.Second))
 	eventParsingExecutor := exec.NewRetryableExecutor[[]*parser.Event](exec.WithMaxRetryCount(1))


### PR DESCRIPTION
Overrides will be useful for types like `types.U256` which, by default, is resolved as a decoder for `[4]types.U64`. This allows us to override that default decoder and use a decoder for `types.U256`.