### PR TITLE
Polkadot update v0.9.43

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.21
 
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install wget && apt-get install ca-certificates -y
 

--- a/client/client.go
+++ b/client/client.go
@@ -33,6 +33,8 @@ type Client interface {
 	// args must be encoded in the format RPC understands
 	Call(result interface{}, method string, args ...interface{}) error
 
+	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
+
 	Subscribe(ctx context.Context, namespace, subscribeMethodSuffix, unsubscribeMethodSuffix,
 		notificationMethodSuffix string, channel interface{}, args ...interface{}) (
 		*gethrpc.ClientSubscription, error)
@@ -73,8 +75,14 @@ func Connect(url string) (Client, error) {
 }
 
 func CallWithBlockHash(c Client, target interface{}, method string, blockHash *types.Hash, args ...interface{}) error {
+	ctx := context.Background()
+
+	return CallWithBlockHashContext(ctx, c, target, method, blockHash, args...)
+}
+
+func CallWithBlockHashContext(ctx context.Context, c Client, target interface{}, method string, blockHash *types.Hash, args ...interface{}) error {
 	if blockHash == nil {
-		err := c.Call(target, method, args...)
+		err := c.CallContext(ctx, target, method, args...)
 		if err != nil {
 			return err
 		}
@@ -85,7 +93,7 @@ func CallWithBlockHash(c Client, target interface{}, method string, blockHash *t
 		return err
 	}
 	args = append(args, hexHash)
-	err = c.Call(target, method, args...)
+	err = c.CallContext(ctx, target, method, args...)
 	if err != nil {
 		return err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -33,11 +33,20 @@ type Client interface {
 	// args must be encoded in the format RPC understands
 	Call(result interface{}, method string, args ...interface{}) error
 
-	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
+	CallContext(
+		ctx context.Context,
+		result interface{},
+		method string,
+		args ...interface{},
+	) error
 
-	Subscribe(ctx context.Context, namespace, subscribeMethodSuffix, unsubscribeMethodSuffix,
-		notificationMethodSuffix string, channel interface{}, args ...interface{}) (
-		*gethrpc.ClientSubscription, error)
+	Subscribe(
+		ctx context.Context,
+		namespace, subscribeMethodSuffix, unsubscribeMethodSuffix,
+		notificationMethodSuffix string,
+		channel interface{},
+		args ...interface{},
+	) (*gethrpc.ClientSubscription, error)
 
 	URL() string
 
@@ -80,7 +89,14 @@ func CallWithBlockHash(c Client, target interface{}, method string, blockHash *t
 	return CallWithBlockHashContext(ctx, c, target, method, blockHash, args...)
 }
 
-func CallWithBlockHashContext(ctx context.Context, c Client, target interface{}, method string, blockHash *types.Hash, args ...interface{}) error {
+func CallWithBlockHashContext(
+	ctx context.Context,
+	c Client,
+	target interface{},
+	method string,
+	blockHash *types.Hash,
+	args ...interface{},
+) error {
 	if blockHash == nil {
 		err := c.CallContext(ctx, target, method, args...)
 		if err != nil {

--- a/client/mocks/Client.go
+++ b/client/mocks/Client.go
@@ -31,6 +31,23 @@ func (_m *Client) Call(result interface{}, method string, args ...interface{}) e
 	return r0
 }
 
+// CallContext provides a mock function with given fields: ctx, result, method, args
+func (_m *Client) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	var _ca []interface{}
+	_ca = append(_ca, ctx, result, method)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}, string, ...interface{}) error); ok {
+		r0 = rf(ctx, result, method, args...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Close provides a mock function with given fields:
 func (_m *Client) Close() {
 	_m.Called()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,12 @@ version: '2'
 services:
   substrate:
     container_name: substrate
-    image: parity/polkadot:v0.9.21
+    image: parity/polkadot:v0.9.43
     ports:
       - 9933:9933
       - 9944:9944
       - 30333:30333
-    command: --dev --rpc-external --ws-external --rpc-methods Unsafe --offchain-worker Always
+    command: --dev --rpc-external --rpc-methods Unsafe --offchain-worker Always
   gsrpc-test:
     image: gsrpc-test
     build: .

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pierrec/xxHash v0.1.5
 	github.com/rs/cors v1.8.2
 	github.com/stretchr/testify v1.7.2
-	github.com/vedhavyas/go-subkey v1.0.4
+	github.com/vedhavyas/go-subkey/v2 v2.0.0
 	golang.org/x/crypto v0.7.0
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/centrifuge/go-substrate-rpc-client/v4
 
-go 1.18
+go 1.21
 
 require (
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBA
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta h1:LTDpDKUM5EeOFBPM8IXpinEcmZ6FWfNZbE3lfrfdnWo=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
+github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce h1:YtWJF7RHm2pYCvA5t0RPmAaLUhREsKuKd+SLhxFbFeQ=
@@ -29,6 +30,7 @@ github.com/decred/base58 v1.0.4/go.mod h1:jJswKPEdvpFpvf7dsDvFZyLT22xZ9lWqEByX38
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
 github.com/ethereum/go-ethereum v1.10.20 h1:75IW830ClSS40yrQC1ZCMZCt5I+zU16oqId2SiQwdQ4=
 github.com/ethereum/go-ethereum v1.10.20/go.mod h1:LWUN82TCHGpxB3En5HVmLLzPD7YSrEUFmFfN1nKkVN0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/ChainSafe/go-schnorrkel v1.0.0/go.mod h1:dpzHYVxLZcp8pjlV+O+UR8K0Hp/z
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
+github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
-github.com/btcsuite/btcd v0.22.0-beta h1:LTDpDKUM5EeOFBPM8IXpinEcmZ6FWfNZbE3lfrfdnWo=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
@@ -77,8 +77,8 @@ github.com/tklauser/go-sysconf v0.3.5 h1:uu3Xl4nkLzQfXNsWn15rPc/HQCJKObbt1dKJeWp
 github.com/tklauser/go-sysconf v0.3.5/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=
 github.com/tklauser/numcpus v0.2.2 h1:oyhllyrScuYI6g+h/zUvNXNp1wy7x8qQy3t/piefldA=
 github.com/tklauser/numcpus v0.2.2/go.mod h1:x3qojaO3uyYt0i56EW/VUYs7uBvdl2fkfZFu0T9wgjM=
-github.com/vedhavyas/go-subkey v1.0.4 h1:QwjBZx4w7qXC2lmqol2jJfhaNXPI9BsgLZiMiCwqGDU=
-github.com/vedhavyas/go-subkey v1.0.4/go.mod h1:aOIil/KS9hJlnr9ZSQKSoXdu/MbnkCxG4x9IOlLsMtI=
+github.com/vedhavyas/go-subkey/v2 v2.0.0 h1:LemDIsrVtRSOkp0FA8HxP6ynfKjeOj3BY2U9UNfeDMA=
+github.com/vedhavyas/go-subkey/v2 v2.0.0/go.mod h1:95aZ+XDCWAUUynjlmi7BtPExjXgXxByE0WfBwbmIRH4=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/main_test.go
+++ b/main_test.go
@@ -50,7 +50,7 @@ func Example_simpleConnect() {
 	}
 
 	fmt.Printf("You are connected to chain %v using %v v%v\n", chain, nodeName, nodeVersion)
-	// Output: You are connected to chain Development using Parity Polkadot v0.9.21-56cbe45f6c9
+	// Output: You are connected to chain Development using Parity Polkadot v0.9.43-ba42b9ce51d
 }
 
 func Example_listenToNewBlocks() {

--- a/registry/factory_test.go
+++ b/registry/factory_test.go
@@ -316,8 +316,6 @@ func TestFactory_CreateCallRegistry_Overrides(t *testing.T) {
 
 	f = NewFactory(fieldOverride).(*factory)
 
-	assert.Equal(t, f.fieldStorage[targetLookupIndex], &ValueDecoder[types.I64]{})
-
 	_, err = f.CreateCallRegistry(&meta)
 	assert.NoError(t, err)
 
@@ -541,8 +539,6 @@ func TestFactory_CreateEventRegistry_Overrides(t *testing.T) {
 
 	f := NewFactory(fieldOverride).(*factory)
 
-	assert.Equal(t, f.fieldStorage[targetLookupIndex], &ValueDecoder[types.DispatchInfo]{})
-
 	_, err = f.CreateEventRegistry(&meta)
 	assert.NoError(t, err)
 
@@ -723,6 +719,7 @@ func TestFactory_getTypeFields(t *testing.T) {
 	}
 
 	factory := NewFactory().(*factory)
+	factory.resetStorages()
 
 	res, err := factory.getTypeFields(testMeta, testFields)
 	assert.NoError(t, err)
@@ -776,6 +773,7 @@ func TestFactory_getTypeFields_FieldDecoderRetrievalError(t *testing.T) {
 	}
 
 	factory := NewFactory().(*factory)
+	factory.resetStorages()
 
 	res, err := factory.getTypeFields(testMeta, testFields)
 	assert.ErrorIs(t, err, ErrFieldDecoderRetrieval)
@@ -948,6 +946,7 @@ func TestFactory_getFieldDecoder_Composite(t *testing.T) {
 	}
 
 	factory := NewFactory().(*factory)
+	factory.resetStorages()
 
 	res, err := factory.getFieldDecoder(testMeta, testFieldName, testFieldTypeDef)
 	assert.NoError(t, err)
@@ -1016,6 +1015,7 @@ func TestFactory_getFieldDecoder_Composite_FieldError(t *testing.T) {
 	}
 
 	factory := NewFactory().(*factory)
+	factory.resetStorages()
 
 	res, err := factory.getFieldDecoder(testMeta, testFieldName, testFieldTypeDef)
 	assert.ErrorIs(t, err, ErrCompositeTypeFieldsRetrieval)
@@ -1074,6 +1074,7 @@ func TestFactory_getFieldDecoder_Variant(t *testing.T) {
 	}
 
 	factory := NewFactory().(*factory)
+	factory.resetStorages()
 
 	res, err := factory.getFieldDecoder(testMeta, testFieldName, testFieldTypeDef)
 	assert.NoError(t, err)
@@ -1638,6 +1639,7 @@ func TestFactory_getVariantFieldType_CompositeVariantTypeFieldError(t *testing.T
 	}
 
 	factory := NewFactory().(*factory)
+	factory.resetStorages()
 
 	res, err := factory.getVariantFieldDecoder(testMeta, testFieldTypeDef)
 	assert.ErrorIs(t, err, ErrVariantTypeFieldsRetrieval)
@@ -2070,8 +2072,6 @@ func TestFactory_Overrides(t *testing.T) {
 	}
 
 	f := NewFactory(fieldOverride).(*factory)
-
-	assert.Equal(t, f.fieldStorage[targetLookupIndex], &ValueDecoder[types.DispatchInfo]{})
 
 	reg, err := f.CreateEventRegistry(&meta)
 	assert.NoError(t, err)

--- a/rpc/author/submit_and_watch_extrinsic_test.go
+++ b/rpc/author/submit_and_watch_extrinsic_test.go
@@ -1,7 +1,6 @@
 package author_test
 
 import (
-	"fmt"
 	"testing"
 
 	gsrpc "github.com/centrifuge/go-substrate-rpc-client/v4"
@@ -57,7 +56,7 @@ func TestAuthor_SubmitAndWatchExtrinsic(t *testing.T) {
 			TransactionVersion: rv.TransactionVersion,
 		}
 
-		fmt.Printf("Sending %v from %#x to %#x with nonce %v\n", amount, signature.TestKeyringPairAlice.PublicKey, bob.AsID, nonce)
+		t.Logf("Sending %v from %#x to %#x with nonce %v\n", amount, signature.TestKeyringPairAlice.PublicKey, bob.AsID, nonce)
 
 		// Sign the transaction using Alice's default account
 		err = ext.Sign(signature.TestKeyringPairAlice, o)

--- a/rpc/chain/generic/chain_test.go
+++ b/rpc/chain/generic/chain_test.go
@@ -1,6 +1,7 @@
 package generic
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -21,20 +22,20 @@ func TestGenericDefaultChain_GetBlock(t *testing.T) {
 
 	blockJustification := []byte{4, 5, 6}
 
-	clientMock.On("Call", mock.Anything, mock.Anything, mock.Anything).
+	clientMock.On("CallContext", context.Background(), mock.Anything, mock.Anything, mock.Anything).
 		Run(
 			func(args mock.Arguments) {
-				target, ok := args.Get(0).(**DefaultGenericSignedBlock)
+				target, ok := args.Get(1).(**DefaultGenericSignedBlock)
 				assert.True(t, ok)
 
 				*target = new(DefaultGenericSignedBlock)
 				(**target).Justification = blockJustification
 
-				method, ok := args.Get(1).(string)
+				method, ok := args.Get(2).(string)
 				assert.True(t, ok)
 				assert.Equal(t, getBlockMethod, method)
 
-				hashStr, ok := args.Get(2).(string)
+				hashStr, ok := args.Get(3).(string)
 				assert.True(t, ok)
 
 				encodedBlockHash := hexutil.Encode(blockHash[:])
@@ -54,17 +55,17 @@ func TestGenericDefaultChain_GetBlock_BlockCallError(t *testing.T) {
 
 	blockHash := types.Hash{1, 2, 3}
 
-	clientMock.On("Call", mock.Anything, mock.Anything, mock.Anything).
+	clientMock.On("CallContext", context.Background(), mock.Anything, mock.Anything, mock.Anything).
 		Run(
 			func(args mock.Arguments) {
-				_, ok := args.Get(0).(**DefaultGenericSignedBlock)
+				_, ok := args.Get(1).(**DefaultGenericSignedBlock)
 				assert.True(t, ok)
 
-				method, ok := args.Get(1).(string)
+				method, ok := args.Get(2).(string)
 				assert.True(t, ok)
 				assert.Equal(t, getBlockMethod, method)
 
-				hashStr, ok := args.Get(2).(string)
+				hashStr, ok := args.Get(3).(string)
 				assert.True(t, ok)
 
 				encodedBlockHash := hexutil.Encode(blockHash[:])
@@ -84,16 +85,16 @@ func TestGenericDefaultChain_GetBlockLatest(t *testing.T) {
 
 	blockJustification := []byte{4, 5, 6}
 
-	clientMock.On("Call", mock.Anything, mock.Anything, mock.Anything).
+	clientMock.On("CallContext", context.Background(), mock.Anything, mock.Anything, mock.Anything).
 		Run(
 			func(args mock.Arguments) {
-				target, ok := args.Get(0).(**DefaultGenericSignedBlock)
+				target, ok := args.Get(1).(**DefaultGenericSignedBlock)
 				assert.True(t, ok)
 
 				*target = new(DefaultGenericSignedBlock)
 				(**target).Justification = blockJustification
 
-				method, ok := args.Get(1).(string)
+				method, ok := args.Get(2).(string)
 				assert.True(t, ok)
 				assert.Equal(t, getBlockMethod, method)
 			},
@@ -109,13 +110,13 @@ func TestGenericDefaultChain_GetBlockLatest_BlockCallError(t *testing.T) {
 
 	genericChain := NewDefaultChain(clientMock)
 
-	clientMock.On("Call", mock.Anything, mock.Anything, mock.Anything).
+	clientMock.On("CallContext", context.Background(), mock.Anything, mock.Anything, mock.Anything).
 		Run(
 			func(args mock.Arguments) {
-				_, ok := args.Get(0).(**DefaultGenericSignedBlock)
+				_, ok := args.Get(1).(**DefaultGenericSignedBlock)
 				assert.True(t, ok)
 
-				method, ok := args.Get(1).(string)
+				method, ok := args.Get(2).(string)
 				assert.True(t, ok)
 				assert.Equal(t, getBlockMethod, method)
 			},
@@ -160,20 +161,20 @@ func (td *testBlockData[A, S, P]) runTest(t *testing.T) {
 
 		blockJustification := []byte{4, 5, 6}
 
-		clientMock.On("Call", mock.Anything, mock.Anything, mock.Anything).
+		clientMock.On("CallContext", context.Background(), mock.Anything, mock.Anything, mock.Anything).
 			Run(
 				func(args mock.Arguments) {
-					target, ok := args.Get(0).(**SignedBlock[A, S, P])
+					target, ok := args.Get(1).(**SignedBlock[A, S, P])
 					assert.True(t, ok)
 
 					*target = new(SignedBlock[A, S, P])
 					(*target).Justification = blockJustification
 
-					method, ok := args.Get(1).(string)
+					method, ok := args.Get(2).(string)
 					assert.True(t, ok)
 					assert.Equal(t, getBlockMethod, method)
 
-					hashStr, ok := args.Get(2).(string)
+					hashStr, ok := args.Get(3).(string)
 					assert.True(t, ok)
 
 					encodedBlockHash := hexutil.Encode(blockHash[:])
@@ -193,17 +194,17 @@ func (td *testBlockData[A, S, P]) runTest(t *testing.T) {
 
 		blockHash := types.Hash{1, 2, 3}
 
-		clientMock.On("Call", mock.Anything, mock.Anything, mock.Anything).
+		clientMock.On("CallContext", context.Background(), mock.Anything, mock.Anything, mock.Anything).
 			Run(
 				func(args mock.Arguments) {
-					_, ok := args.Get(0).(**SignedBlock[A, S, P])
+					_, ok := args.Get(1).(**SignedBlock[A, S, P])
 					assert.True(t, ok)
 
-					method, ok := args.Get(1).(string)
+					method, ok := args.Get(2).(string)
 					assert.True(t, ok)
 					assert.Equal(t, getBlockMethod, method)
 
-					hashStr, ok := args.Get(2).(string)
+					hashStr, ok := args.Get(3).(string)
 					assert.True(t, ok)
 
 					encodedBlockHash := hexutil.Encode(blockHash[:])
@@ -223,16 +224,16 @@ func (td *testBlockData[A, S, P]) runTest(t *testing.T) {
 
 		blockJustification := []byte{4, 5, 6}
 
-		clientMock.On("Call", mock.Anything, mock.Anything, mock.Anything).
+		clientMock.On("CallContext", context.Background(), mock.Anything, mock.Anything, mock.Anything).
 			Run(
 				func(args mock.Arguments) {
-					target, ok := args.Get(0).(**SignedBlock[A, S, P])
+					target, ok := args.Get(1).(**SignedBlock[A, S, P])
 					assert.True(t, ok)
 
 					*target = new(SignedBlock[A, S, P])
 					(*target).Justification = blockJustification
 
-					method, ok := args.Get(1).(string)
+					method, ok := args.Get(2).(string)
 					assert.True(t, ok)
 					assert.Equal(t, getBlockMethod, method)
 				},
@@ -248,13 +249,13 @@ func (td *testBlockData[A, S, P]) runTest(t *testing.T) {
 
 		genericChain := NewChain[A, S, P, *SignedBlock[A, S, P]](clientMock)
 
-		clientMock.On("Call", mock.Anything, mock.Anything, mock.Anything).
+		clientMock.On("CallContext", context.Background(), mock.Anything, mock.Anything, mock.Anything).
 			Run(
 				func(args mock.Arguments) {
-					_, ok := args.Get(0).(**SignedBlock[A, S, P])
+					_, ok := args.Get(1).(**SignedBlock[A, S, P])
 					assert.True(t, ok)
 
-					method, ok := args.Get(1).(string)
+					method, ok := args.Get(2).(string)
 					assert.True(t, ok)
 					assert.Equal(t, getBlockMethod, method)
 				},

--- a/signature/signature.go
+++ b/signature/signature.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/vedhavyas/go-subkey"
-	"github.com/vedhavyas/go-subkey/sr25519"
+	"github.com/vedhavyas/go-subkey/v2"
+	"github.com/vedhavyas/go-subkey/v2/sr25519"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/types/account_data.go
+++ b/types/account_data.go
@@ -26,6 +26,6 @@ type AccountInfo struct {
 		Free       U128
 		Reserved   U128
 		MiscFrozen U128
-		FreeFrozen U128
+		Flags      U128
 	}
 }

--- a/types/address.go
+++ b/types/address.go
@@ -37,7 +37,7 @@ func NewAddressFromAccountID(b []byte) (Address, error) {
 	accountID, err := NewAccountID(b)
 
 	if err != nil {
-		return Address{}, nil
+		return Address{}, err
 	}
 
 	return Address{


### PR DESCRIPTION
This PR is aimed at updating some of the types that were updated with `polkadot-v0.9.43` and some other minor updates to the lib.