### PR TITLE
Add missing events of `pallet-assets`

### DIFF
--- a/types/event_record.go
+++ b/types/event_record.go
@@ -71,24 +71,30 @@ type EventRecords struct {
 	Auctions_BidAccepted        []EventAuctionsBidAccepted        `test-gen-blockchain:"polkadot"`
 	Auctions_WinningOffset      []EventAuctionsWinningOffset      `test-gen-blockchain:"polkadot"`
 
-	Assets_Created             []EventAssetCreated             `test-gen-skip:"true"`
-	Assets_Issued              []EventAssetIssued              `test-gen-skip:"true"`
-	Assets_Transferred         []EventAssetTransferred         `test-gen-skip:"true"`
-	Assets_Burned              []EventAssetBurned              `test-gen-skip:"true"`
-	Assets_TeamChanged         []EventAssetTeamChanged         `test-gen-skip:"true"`
-	Assets_OwnerChanged        []EventAssetOwnerChanged        `test-gen-skip:"true"`
-	Assets_Frozen              []EventAssetFrozen              `test-gen-skip:"true"`
-	Assets_Thawed              []EventAssetThawed              `test-gen-skip:"true"`
-	Assets_AssetFrozen         []EventAssetAssetFrozen         `test-gen-skip:"true"`
-	Assets_AssetThawed         []EventAssetAssetThawed         `test-gen-skip:"true"`
-	Assets_Destroyed           []EventAssetDestroyed           `test-gen-skip:"true"`
-	Assets_ForceCreated        []EventAssetForceCreated        `test-gen-skip:"true"`
-	Assets_MetadataSet         []EventAssetMetadataSet         `test-gen-skip:"true"`
-	Assets_MetadataCleared     []EventAssetMetadataCleared     `test-gen-skip:"true"`
-	Assets_ApprovedTransfer    []EventAssetApprovedTransfer    `test-gen-skip:"true"`
-	Assets_ApprovalCancelled   []EventAssetApprovalCancelled   `test-gen-skip:"true"`
-	Assets_TransferredApproved []EventAssetTransferredApproved `test-gen-skip:"true"`
-	Assets_AssetStatusChanged  []EventAssetAssetStatusChanged  `test-gen-skip:"true"`
+	Assets_Created                []EventAssetCreated                `test-gen-skip:"true"`
+	Assets_Issued                 []EventAssetIssued                 `test-gen-skip:"true"`
+	Assets_Transferred            []EventAssetTransferred            `test-gen-skip:"true"`
+	Assets_Burned                 []EventAssetBurned                 `test-gen-skip:"true"`
+	Assets_TeamChanged            []EventAssetTeamChanged            `test-gen-skip:"true"`
+	Assets_OwnerChanged           []EventAssetOwnerChanged           `test-gen-skip:"true"`
+	Assets_Frozen                 []EventAssetFrozen                 `test-gen-skip:"true"`
+	Assets_Thawed                 []EventAssetThawed                 `test-gen-skip:"true"`
+	Assets_AssetFrozen            []EventAssetAssetFrozen            `test-gen-skip:"true"`
+	Assets_AssetThawed            []EventAssetAssetThawed            `test-gen-skip:"true"`
+	Assets_AccountsDestroyed      []EventAssetAccountsDestroyed      `test-gen-skip:"true"`
+	Assets_ApprovalsDestroyed     []EventAssetApprovalsDestroyed     `test-gen-skip:"true"`
+	Assets_DestructionStarted     []EventAssetDestructionStarted     `test-gen-skip:"true"`
+	Assets_Destroyed              []EventAssetDestroyed              `test-gen-skip:"true"`
+	Assets_ForceCreated           []EventAssetForceCreated           `test-gen-skip:"true"`
+	Assets_MetadataSet            []EventAssetMetadataSet            `test-gen-skip:"true"`
+	Assets_MetadataCleared        []EventAssetMetadataCleared        `test-gen-skip:"true"`
+	Assets_ApprovedTransfer       []EventAssetApprovedTransfer       `test-gen-skip:"true"`
+	Assets_ApprovalCancelled      []EventAssetApprovalCancelled      `test-gen-skip:"true"`
+	Assets_TransferredApproved    []EventAssetTransferredApproved    `test-gen-skip:"true"`
+	Assets_AssetStatusChanged     []EventAssetAssetStatusChanged     `test-gen-skip:"true"`
+	Assets_AssetMinBalanceChanged []EventAssetAssetMinBalanceChanged `test-gen-skip:"true"`
+	Assets_Touched                []EventAssetTouched                `test-gen-skip:"true"`
+	Assets_Blocked                []EventAssetBlocked                `test-gen-skip:"true"`
 
 	BagsList_Rebagged []EventBagsListRebagged `test-gen-blockchain:"polkadot"`
 

--- a/types/events.go
+++ b/types/events.go
@@ -1071,6 +1071,31 @@ type EventAssetAssetThawed struct {
 	Topics  []Hash
 }
 
+// EventAssetAccountsDestroyed is emitted when accounts were destroyed for given asset.
+type EventAssetAccountsDestroyed struct {
+	Phase             Phase
+	AssetID           U32
+	AccountsDestroyed U32
+	AccountsRemaining U32
+	Topics            []Hash
+}
+
+// EventAssetApprovalsDestroyed is emitted when approvals were destroyed for given asset.
+type EventAssetApprovalsDestroyed struct {
+	Phase              Phase
+	AssetID            U32
+	ApprovalsDestroyed U32
+	ApprovalsRemaining U32
+	Topics             []Hash
+}
+
+// EventAssetDestructionStarted is emitted when an asset class is in the process of being destroyed.
+type EventAssetDestructionStarted struct {
+	Phase   Phase
+	AssetID U32
+	Topics  []Hash
+}
+
 // EventAssetDestroyed is emitted when an asset class is destroyed.
 type EventAssetDestroyed struct {
 	Phase   Phase
@@ -1143,6 +1168,31 @@ type EventAssetTransferredApproved struct {
 type EventAssetAssetStatusChanged struct {
 	Phase   Phase
 	AssetID U32
+	Topics  []Hash
+}
+
+// EventAssetAssetMinBalanceChanged is emitted when the MinBalance of an asset has been updated by the asset owner.
+type EventAssetAssetMinBalanceChanged struct {
+	Phase         Phase
+	AssetID       U32
+	NewMinBalance U128
+	Topics        []Hash
+}
+
+// EventAssetTouched is emitted when some account Who was created with a deposit from Depositor.
+type EventAssetTouched struct {
+	Phase     Phase
+	AssetID   U32
+	Who       AccountID
+	Depositor AccountID
+	Topics    []Hash
+}
+
+// EventAssetBlocked is emitted when some account Who was blocked.
+type EventAssetBlocked struct {
+	Phase   Phase
+	AssetID U32
+	Who     AccountID
 	Topics  []Hash
 }
 


### PR DESCRIPTION
Hello. I'm using the package to process events of a [polkadot-v1.0.0](https://github.com/paritytech/substrate/tree/polkadot-v1.0.0) based chain with an older `EventRecords` decoding method. Several event types are not defined in the package yet. This patch adds missing types of the `pallet-assets`.

Are you accepting PRs with new events definitions and is it valuable to make a PR with definitions for other pallets? Or I better migrate my application to the new `GSRPC Registry` approach for events listening? Thank you.